### PR TITLE
fixes for playtest

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -31,10 +31,10 @@
 
 	if(ntitle)
 		set_title(ntitle)
-	
+
 	if(nwidth)
 		width = nwidth
-	
+
 	if(nheight)
 		height = nheight
 
@@ -151,9 +151,9 @@
  * Otherwise, the user mob's machine var will be reset directly.
  */
 /proc/onclose(mob/user, windowid, atom/ref)
-	if(!user || !user.client) 
+	if(!user || !user.client)
 		return
-	
+
 	var/param = ref ? "\ref[ref]" : "null"
 	addtimer(CALLBACK(user, /mob/proc/post_onclose, windowid, param), 2)
 
@@ -162,9 +162,9 @@
 		winset(src, windowid, "on-close=\".windowclose [param]\"")
 
 
-/** 
+/**
  * the on-close client verb
- * 
+ *
  * called when a browser popup window is closed after registering with proc/onclose()
  * if a valid atom reference is supplied, call the atom's Topic() with "close=1"
  * otherwise, just reset the client mob's machine var.
@@ -181,3 +181,7 @@
 
 	if (src?.mob)
 		mob.unset_machine()
+
+// Resize already opened window
+/datum/browser/proc/resize(var/new_width = width, var/new_height = height)
+    winset(user, "[window_id]", "size=[new_width]x[new_height]")

--- a/code/game/area/area_abstract.dm
+++ b/code/game/area/area_abstract.dm
@@ -1,5 +1,7 @@
 /area/hallway
 	name = "hallway"
+	secure = TRUE
+	area_flags = AREA_FLAG_HALLWAY
 
 /area/maintenance
 	area_flags = AREA_FLAG_RAD_SHIELDED
@@ -7,6 +9,7 @@
 	turf_initializer = /decl/turf_initializer/maintenance
 	forced_ambience = list('sound/ambience/maintambience.ogg')
 	req_access = list(access_maint_tunnels)
+	secure = TRUE
 
 /area/shuttle
 	requires_power = 0

--- a/code/game/objects/items/devices/scanners/_scanner.dm
+++ b/code/game/objects/items/devices/scanners/_scanner.dm
@@ -28,6 +28,7 @@
 	var/datum/browser/written_digital/popup = new(user, "scanner", scan_title, window_width, window_height)
 	popup.set_content("[get_header()]<hr>[scan_data]")
 	popup.open()
+	popup.resize(window_width,window_height)
 
 /obj/item/scanner/proc/get_header()
 	return "<a href='?src=\ref[src];print=1'>Print Report</a><a href='?src=\ref[src];clear=1'>Clear data</a>"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -7,7 +7,7 @@
 
 	layer = SIDE_WINDOW_LAYER
 	anchored = 1.0
-	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CAN_BE_PAINTED
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CHECKS_BORDER | ATOM_FLAG_CAN_BE_PAINTED
 	obj_flags = OBJ_FLAG_ROTATABLE
 	alpha = 180
 	material = /decl/material/solid/glass
@@ -51,6 +51,7 @@
 		if(!isnull(dir_to_set))
 			set_dir(dir_to_set)
 		if(is_fulltile())
+			atom_flags &= ~ATOM_FLAG_CHECKS_BORDER
 			layer = FULL_WINDOW_LAYER
 		. = INITIALIZE_HINT_LATELOAD
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -7,7 +7,7 @@
 
 	layer = SIDE_WINDOW_LAYER
 	anchored = 1.0
-	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CHECKS_BORDER | ATOM_FLAG_CAN_BE_PAINTED
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CAN_BE_PAINTED
 	obj_flags = OBJ_FLAG_ROTATABLE
 	alpha = 180
 	material = /decl/material/solid/glass

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -290,18 +290,6 @@
 	var/DBQuery/query_update = dbcon.NewQuery("UPDATE `erro_ban` SET `unbanned` = TRUE, `unbanned_datetime` = NOW(), `unbanned_ckey` = '[unban_ckey]', `unbanned_computerid` = '[unban_computerid]', `unbanned_ip` = '[unban_ip]' WHERE `id` = [id]")
 	query_update.Execute()
 
-
-/client/proc/DB_ban_panel()
-	set category = "Admin"
-	set name = "Banning Panel"
-	set desc = "Edit admin permissions"
-
-	if(!holder)
-		return
-
-	holder.DB_ban_panel()
-
-
 /datum/admins/proc/DB_ban_panel(var/playerckey = null, var/adminckey = null, var/playerip = null, var/playercid = null, var/dbbantype = null, var/match = null)
 	if(!usr.client)
 		return

--- a/code/modules/admin/Dbban/functions.dm
+++ b/code/modules/admin/Dbban/functions.dm
@@ -290,6 +290,16 @@
 	var/DBQuery/query_update = dbcon.NewQuery("UPDATE `erro_ban` SET `unbanned` = TRUE, `unbanned_datetime` = NOW(), `unbanned_ckey` = '[unban_ckey]', `unbanned_computerid` = '[unban_computerid]', `unbanned_ip` = '[unban_ip]' WHERE `id` = [id]")
 	query_update.Execute()
 
+/client/proc/DB_ban_panel()
+	set name = "Banning Panel"
+	set category = "Admin"
+	set desc = "Allow edit existing bans or create new ones."
+
+	if(!holder)
+		return
+
+	holder.DB_ban_panel()
+
 /datum/admins/proc/DB_ban_panel(var/playerckey = null, var/adminckey = null, var/playerip = null, var/playercid = null, var/dbbantype = null, var/match = null)
 	if(!usr.client)
 		return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -95,7 +95,8 @@ var/global/list/admin_verbs_admin = list(
 )
 var/global/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
-	/client/proc/jobbans
+	/client/proc/jobbans,
+	/client/proc/DB_ban_panel
 	)
 var/global/list/admin_verbs_sounds = list(
 	/client/proc/play_local_sound,
@@ -480,6 +481,16 @@ var/global/list/admin_verbs_mod = list(
 			holder.DB_ban_panel()
 	SSstatistics.add_field_details("admin_verb","UBP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
+
+/client/proc/DB_ban_panel()
+	set name = "Banning Panel"
+	set category = "Admin"
+	set desc = "Edit admin permissions"
+
+	if(!holder)
+		return
+
+	holder.DB_ban_panel()
 
 /client/proc/game_panel()
 	set name = "Game Panel"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -482,16 +482,6 @@ var/global/list/admin_verbs_mod = list(
 	SSstatistics.add_field_details("admin_verb","UBP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
-/client/proc/DB_ban_panel()
-	set name = "Banning Panel"
-	set category = "Admin"
-	set desc = "Edit admin permissions"
-
-	if(!holder)
-		return
-
-	holder.DB_ban_panel()
-
 /client/proc/game_panel()
 	set name = "Game Panel"
 	set category = "Admin"

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -85,7 +85,8 @@
 	if(eyeobj)
 		eyeobj.possess(src)
 
-	client.update_skybox(1)
+	spawn(1)
+		client.update_skybox(1)
 	events_repository.raise_event(/decl/observ/logged_in, src)
 
 	hud_reset(TRUE)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -525,7 +525,7 @@
 	material = /decl/material/solid/glass
 	matter = list(/decl/material/solid/metal/aluminium = MATTER_AMOUNT_REINFORCEMENT)
 
-	b_range = 8
+	b_range = 6
 	b_power = 0.8
 	b_color = LIGHT_COLOR_HALOGEN
 	lighting_modes = list(
@@ -540,8 +540,8 @@
 /obj/item/light/tube/large
 	w_class = ITEM_SIZE_SMALL
 	name = "large light tube"
-	b_power = 4
-	b_range = 12
+	b_power = 1
+	b_range = 8
 
 /obj/item/light/tube/large/party/Initialize() //Randomly colored light tubes. Mostly for testing, but maybe someone will find a use for them.
 	. = ..()

--- a/code/modules/xenoarcheaology/machinery/artifact_analyser.dm
+++ b/code/modules/xenoarcheaology/machinery/artifact_analyser.dm
@@ -3,6 +3,8 @@
 	desc = "Studies the emissions of anomalous materials to discover their uses."
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "xenoarch_analyser1"
+	anchored = 1
+	density = 1
 	var/obj/scanned_object
 	var/obj/machinery/artifact_scanpad/owned_scanner
 	var/scanning_counter = 0
@@ -17,7 +19,7 @@
 
 /obj/machinery/artifact_analyser/on_update_icon()
 	icon_state = "xenoarch_analyser[operable()]"
-	
+
 /obj/machinery/artifact_analyser/Initialize()
 	. = ..()
 	reconnect_scanner()
@@ -93,7 +95,7 @@
 		state("Error communicating with the scanner pad.")
 		stop_scan()
 		return
-	
+
 	if(!scanned_object || scanned_object.loc != owned_scanner.loc)
 		state("Unable to locate scanned object. Ensure it was not moved in the process.")
 		stop_scan()
@@ -123,19 +125,19 @@
 			if(O == owned_scanner || O.invisibility || !O.simulated)
 				continue
 			set_object(O)
-			scanning_counter = scan_duration	
+			scanning_counter = scan_duration
 			state("Scanning of \the [O] initiated.")
 			playsound(loc, "sound/effects/ping.ogg", 50, 1)
 			break
 		if(!scanned_object)
 			state("Unable to isolate a scan target.")
 		. = TOPIC_REFRESH
-	
+
 	if(href_list["halt_scan"])
 		stop_scan()
 		state("Scanning halted.")
 		. = TOPIC_REFRESH
-	
+
 	if(href_list["print"])
 		if(length(stored_scan))
 			playsound(loc, "sound/machines/dotprinter.ogg", 30, 1)

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -104,7 +104,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "av" = (
 /obj/item/stool/bar,
 /turf/simulated/floor/wood/walnut{
@@ -173,7 +173,7 @@
 /area/quartermaster/expedition)
 "aF" = (
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "aH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -196,7 +196,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "aJ" = (
 /turf/simulated/wall/prepainted,
 /area/quartermaster/hangar)
@@ -239,7 +239,7 @@
 	},
 /obj/effect/floor_decal/corner/brown/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "aO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -288,7 +288,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "aT" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
@@ -686,7 +686,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "bY" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -913,7 +913,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "cu" = (
 /obj/structure/bed/padded,
 /obj/effect/floor_decal/corner/green{
@@ -1231,7 +1231,7 @@
 /obj/structure/stairs/west,
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "dc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -2147,7 +2147,7 @@
 /area/quartermaster/hangar)
 "fl" = (
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "fm" = (
 /obj/machinery/light{
 	dir = 8;
@@ -2382,7 +2382,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "fW" = (
 /obj/effect/floor_decal/corner/mauve/half{
 	dir = 4
@@ -2552,7 +2552,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "gw" = (
 /obj/machinery/light/spot{
 	dir = 1
@@ -2634,7 +2634,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "gI" = (
 /turf/simulated/wall/map_preset/tan,
 /area/maintenance/fifthdeck/aftport)
@@ -2642,7 +2642,7 @@
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "gL" = (
 /obj/machinery/shipsensors/weak,
 /turf/simulated/floor/plating,
@@ -2769,7 +2769,7 @@
 	},
 /obj/structure/sign/warning/pods/south,
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "hk" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mining/brace{
@@ -2823,14 +2823,14 @@
 "hu" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "hv" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "hw" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
@@ -2895,7 +2895,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "hL" = (
 /obj/machinery/sleeper/standard,
 /obj/machinery/vending/wallmed1{
@@ -3031,7 +3031,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "im" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3164,7 +3164,7 @@
 /area/quartermaster/expedition/storage)
 "iE" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "iF" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/dispenser,
@@ -3585,7 +3585,7 @@
 /area/quartermaster/expedition/eva)
 "jD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_cycler/pilot/prepared,
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
 "jE" = (
@@ -3698,7 +3698,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "jP" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 1
@@ -3709,7 +3709,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "jQ" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3905,7 +3905,7 @@
 /area/quartermaster/exploration)
 "kl" = (
 /turf/unsimulated/mask,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "kn" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -4429,7 +4429,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "lv" = (
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -4893,7 +4893,7 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "mN" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -4904,7 +4904,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "mP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -4932,7 +4932,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "mR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4999,7 +4999,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "nb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5104,7 +5104,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "nm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -5813,7 +5813,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "oE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -5824,7 +5824,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "oF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5858,7 +5858,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "oI" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/cyan{
@@ -5874,7 +5874,7 @@
 "oJ" = (
 /obj/turbolift_map_holder/torch,
 /turf/unsimulated/mask,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "oL" = (
 /obj/effect/paint/tan,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -5915,7 +5915,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "oR" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4
@@ -5924,7 +5924,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "oS" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4
@@ -5938,7 +5938,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "oT" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/camera/network/hangar{
@@ -5954,7 +5954,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "oW" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 8
@@ -5964,7 +5964,7 @@
 	pixel_y = -38
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "oX" = (
 /obj/effect/floor_decal/corner/mauve/half,
 /obj/machinery/light,
@@ -5977,23 +5977,23 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "oY" = (
 /obj/effect/floor_decal/corner/mauve,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "oZ" = (
 /obj/effect/floor_decal/corner/mauve/half{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "pa" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "pb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -6062,7 +6062,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "pl" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6082,7 +6082,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "pn" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -6097,7 +6097,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "pp" = (
 /obj/structure/sign/directions/bridge{
 	dir = 1;
@@ -6108,7 +6108,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "pq" = (
 /obj/structure/sign/directions/science{
 	dir = 1;
@@ -6119,7 +6119,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "pr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -6583,7 +6583,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "qx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
@@ -6599,7 +6599,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "qz" = (
 /obj/machinery/alarm{
 	alarm_id = "curiosity2";
@@ -6613,14 +6613,14 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "qA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "qB" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -6634,7 +6634,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "qC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6646,7 +6646,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "qD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -6673,7 +6673,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "qF" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -6683,7 +6683,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "qG" = (
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/map_preset/tan,
@@ -6694,7 +6694,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "qI" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -6708,13 +6708,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "qJ" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "qK" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -6723,7 +6723,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "qL" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6734,7 +6734,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "qM" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6760,7 +6760,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "qO" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -6774,7 +6774,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "qP" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -6806,7 +6806,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "qS" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -7010,7 +7010,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7110,7 +7110,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/green/mono,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "rC" = (
 /obj/structure/cable/cyan{
@@ -7208,7 +7208,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rM" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -7222,7 +7222,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rN" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -7236,7 +7236,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7246,7 +7246,7 @@
 	},
 /obj/item/radio/beacon,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rP" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7257,7 +7257,7 @@
 	},
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rQ" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7267,7 +7267,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rR" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -7282,21 +7282,21 @@
 	sort_type = "Pilot's Lounge"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rS" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rT" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "rV" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -7469,18 +7469,18 @@
 	pixel_x = 40
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "sn" = (
 /obj/effect/floor_decal/corner/mauve/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "so" = (
 /obj/effect/floor_decal/corner/brown/mono,
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "sp" = (
 /obj/machinery/camera/network/expedition{
 	c_tag = "Expedition - Prep";
@@ -7587,7 +7587,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "sI" = (
 /obj/abstract/landmark{
 	name = "xeno_spawn";
@@ -7956,7 +7956,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "tG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7982,7 +7982,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "tU" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -8151,7 +8151,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "un" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -8165,7 +8165,7 @@
 	},
 /obj/item/radio/beacon,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "uo" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/sortjunction/flipped{
@@ -8182,7 +8182,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "up" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8193,7 +8193,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "uq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8201,7 +8201,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "ur" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8209,7 +8209,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "us" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -8221,7 +8221,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "ut" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
@@ -8229,7 +8229,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "uu" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -8240,7 +8240,7 @@
 	level = 2
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "uv" = (
 /obj/random/trash,
 /obj/structure/railing/mapped{
@@ -8273,7 +8273,7 @@
 "uy" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "uz" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -8696,7 +8696,7 @@
 	},
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "wA" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -8792,14 +8792,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "xl" = (
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "xp" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -9065,7 +9065,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "yY" = (
 /obj/machinery/cryopod{
 	dir = 2
@@ -9085,7 +9085,7 @@
 "zb" = (
 /obj/machinery/cryopod{
 	dir = 1;
-	icon_state = "body_scanner_0"
+	icon_state = "open"
 	},
 /obj/machinery/computer/cryopod{
 	pixel_y = -32
@@ -9188,7 +9188,7 @@
 /area/vacant/bar)
 "zS" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "zV" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -10025,7 +10025,7 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "Fk" = (
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "Fn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -10065,7 +10065,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "FR" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-4"
@@ -10459,7 +10459,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset/torch,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "HR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -10740,7 +10740,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "JV" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/light/spot{
@@ -10926,7 +10926,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "Lf" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
@@ -11223,7 +11223,7 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "MR" = (
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "MS" = (
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage)
@@ -11344,7 +11344,7 @@
 	},
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "Ol" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable{
@@ -11479,7 +11479,7 @@
 /area/bridge/ai/ai)
 "Pv" = (
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "Py" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/techfloor,
@@ -11549,7 +11549,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/green/mono,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "Qd" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -11753,11 +11753,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "Rp" = (
 /obj/structure/sign/warning/pods,
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "Rv" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -11842,10 +11842,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "Sd" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "Sf" = (
 /obj/machinery/light{
 	dir = 1
@@ -11882,7 +11882,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "Sv" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -12032,7 +12032,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "Ts" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/r_wall/prepainted,
@@ -12108,7 +12108,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "TQ" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
@@ -12116,7 +12116,7 @@
 "Ua" = (
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/fore)
+/area/hallway/fifthdeck/fore)
 "Ud" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
@@ -12198,7 +12198,7 @@
 /area/maintenance/fifthdeck/fore)
 "UO" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "UV" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
@@ -12260,7 +12260,7 @@
 "Vz" = (
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "VA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
@@ -12311,7 +12311,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "VR" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -12552,7 +12552,7 @@
 "Xl" = (
 /obj/machinery/cryopod{
 	dir = 1;
-	icon_state = "body_scanner_0"
+	icon_state = "open"
 	},
 /obj/machinery/computer/cryopod{
 	pixel_y = -32
@@ -12611,7 +12611,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "XD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -12626,7 +12626,7 @@
 	},
 /obj/structure/sign/warning/compressed_gas,
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "XI" = (
 /turf/simulated/wall/prepainted,
 /area/vacant/bar)
@@ -12857,7 +12857,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "ZE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -12885,7 +12885,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/hallway/fifthdeck/aft)
 "ZR" = (
 /obj/structure/bed/chair/armchair/beige{
 	dir = 4

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -22,7 +22,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "aj" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -48,7 +48,7 @@
 /area/maintenance/fourthdeck/port)
 "am" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "an" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -179,7 +179,7 @@
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/effect/paint/tan,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "aK" = (
 /obj/machinery/door/airlock/external{
 	icon_state = "closed";
@@ -189,7 +189,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "aQ" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fourthdeck/starboard)
@@ -238,7 +238,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "be" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -305,7 +305,7 @@
 	tag_interior_door = "admin_shuttle_dock_inner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "bm" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/machinery/door/firedoor,
@@ -322,7 +322,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "bn" = (
 /obj/effect/shuttle_landmark/torch/deck5/perseverance{
 	name = "4th Deck, Aft"
@@ -365,7 +365,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "by" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -379,7 +379,7 @@
 "bz" = (
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "bA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -401,7 +401,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "bC" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -411,7 +411,7 @@
 "bE" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "bF" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -446,7 +446,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "bM" = (
 /obj/effect/shuttle_landmark/merchant/out,
 /turf/space,
@@ -606,7 +606,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "cr" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -623,11 +623,11 @@
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "cv" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "cw" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
@@ -845,7 +845,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "dd" = (
 /obj/machinery/door/airlock/external/escapepod{
 	icon_state = "closed";
@@ -854,7 +854,7 @@
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "dg" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -879,7 +879,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "dj" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 4;
@@ -923,7 +923,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "ds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
@@ -1049,7 +1049,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "dM" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8;
@@ -1150,7 +1150,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "el" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	display_name = "Starboard Dock A";
@@ -1165,7 +1165,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "en" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -1345,7 +1345,7 @@
 	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "eY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -1357,7 +1357,7 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "fa" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/nt_regs,
@@ -1399,7 +1399,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "fk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/firealarm{
@@ -1408,7 +1408,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "fl" = (
 /obj/effect/paint_stripe/science,
 /turf/simulated/wall/map_preset/tan,
@@ -1600,7 +1600,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "fL" = (
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
@@ -1621,7 +1621,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "fX" = (
 /obj/structure/catwalk,
 /obj/structure/railing/mapped{
@@ -1660,7 +1660,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "gb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1668,7 +1668,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "gc" = (
 /obj/effect/floor_decal/corner/mauve/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1761,7 +1761,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "gr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -1818,12 +1818,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "gM" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "gX" = (
 /obj/structure/disposalpipe/down{
 	dir = 8
@@ -1888,13 +1888,13 @@
 	req_access = list("ACCESS_CARGO")
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "hc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "hd" = (
 /obj/effect/floor_decal/corner/mauve/mono,
 /obj/machinery/power/apc{
@@ -2051,7 +2051,7 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "hw" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2156,7 +2156,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "hU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2166,7 +2166,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "hV" = (
 /obj/effect/floor_decal/corner/mauve/half{
 	dir = 8
@@ -2312,7 +2312,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/internals,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "iM" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -2360,7 +2360,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "iZ" = (
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/auxillary/starboard)
@@ -2410,7 +2410,7 @@
 	pixel_x = 21
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "jf" = (
 /obj/effect/floor_decal/corner/mauve/half{
 	dir = 8
@@ -2537,7 +2537,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "jF" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -2625,7 +2625,7 @@
 /area/crew_quarters/commissary)
 "kl" = (
 /turf/unsimulated/mask,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "ko" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -2661,7 +2661,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "kw" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -2695,7 +2695,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "kF" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/cable/green{
@@ -2778,14 +2778,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "kX" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "kZ" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
@@ -2806,7 +2806,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "lb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -2832,10 +2832,10 @@
 	name = "Fore Starboad Docking Access"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "le" = (
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "lf" = (
 /obj/machinery/door/airlock/science{
 	name = "Pathfinder's Office"
@@ -2869,7 +2869,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "lk" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -2999,7 +2999,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "lP" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -3073,7 +3073,7 @@
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mf" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3088,7 +3088,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mg" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3100,7 +3100,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mh" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3108,7 +3108,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mi" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3128,14 +3128,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mk" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3150,7 +3150,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "ml" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3163,7 +3163,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mm" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3178,7 +3178,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mn" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3188,7 +3188,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mo" = (
 /obj/machinery/hologram/holopad/longrange,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3206,7 +3206,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3225,7 +3225,7 @@
 	},
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "ms" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -3236,7 +3236,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mt" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -3252,7 +3252,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "mw" = (
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -3300,7 +3300,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "mG" = (
 /obj/structure/railing/mapped,
 /turf/simulated/open,
@@ -3351,7 +3351,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "mR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -3363,7 +3363,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "mS" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating,
@@ -3434,7 +3434,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -3444,7 +3444,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3454,7 +3454,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3465,7 +3465,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "no" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -3477,7 +3477,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "np" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -3485,7 +3485,7 @@
 	},
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nq" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -3496,7 +3496,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nr" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -3511,7 +3511,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "ns" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -3520,7 +3520,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nt" = (
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
@@ -3529,7 +3529,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3551,7 +3551,7 @@
 	},
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nv" = (
 /obj/structure/sign/directions/bridge{
 	dir = 1;
@@ -3562,7 +3562,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3575,7 +3575,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nA" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3589,7 +3589,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "nC" = (
 /turf/simulated/wall/map_preset/tan,
 /area/maintenance/fourthdeck/forestarboard)
@@ -3648,7 +3648,7 @@
 	name = "Emergency Storage"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "od" = (
 /obj/structure/grille,
 /turf/simulated/floor/tiled/techmaint,
@@ -3680,7 +3680,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "os" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
 	dir = 1
@@ -3747,7 +3747,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "oy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3756,7 +3756,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "oz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3769,7 +3769,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "oA" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/teleporter/fourthdeck)
@@ -3798,10 +3798,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "oF" = (
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "oG" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -3816,7 +3816,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "oI" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3826,7 +3826,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "oJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -3949,7 +3949,7 @@
 /obj/random/maintenance/solgov/clean,
 /obj/structure/closet/crate/plastic,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "pp" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
@@ -3958,14 +3958,14 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset/torch,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "pu" = (
 /obj/effect/floor_decal/corner/green/three_quarters,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "px" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -4024,7 +4024,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "pK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4032,7 +4032,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "pL" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -4117,11 +4117,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "pV" = (
 /obj/structure/stairs/east,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "pW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4148,7 +4148,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "pZ" = (
 /obj/structure/sign/directions/science{
 	dir = 1;
@@ -4159,13 +4159,13 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "qa" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "qb" = (
 /obj/structure/sign/directions/bridge{
 	dir = 1;
@@ -4218,7 +4218,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "ql" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -4227,7 +4227,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "qn" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -4347,7 +4347,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "qV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4359,7 +4359,7 @@
 	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "qW" = (
 /obj/machinery/teleport/station,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -4430,7 +4430,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "rg" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 4
@@ -4438,25 +4438,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "rh" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "ri" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "rj" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "rk" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -4477,7 +4477,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "rm" = (
 /obj/structure/railing/mapped,
 /obj/machinery/light/spot{
@@ -4496,7 +4496,7 @@
 /area/maintenance/fourthdeck/port)
 "rp" = (
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "rr" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plating,
@@ -4534,6 +4534,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
+"rw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/structure/table/steel,
+/turf/simulated/floor/plating,
+/area/eva)
 "rz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
@@ -4541,7 +4558,7 @@
 	name = "Ladderwell"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "rC" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/space)
@@ -4589,7 +4606,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "rO" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -4627,7 +4644,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "sf" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -4677,6 +4694,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/eva)
 "sn" = (
@@ -4736,7 +4754,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "sq" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -4757,7 +4775,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "sr" = (
 /obj/machinery/computer/teleporter{
 	dir = 4
@@ -4840,7 +4858,7 @@
 	sort_type = "Pathfinder's Office"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "sA" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -4858,7 +4876,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "sB" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4875,7 +4893,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "sC" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4890,7 +4908,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "sD" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4909,7 +4927,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "sF" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4925,7 +4943,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "sG" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4942,7 +4960,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "sH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4961,7 +4979,7 @@
 	},
 /obj/item/radio/beacon,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "sI" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -4975,13 +4993,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "sJ" = (
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "sK" = (
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "sL" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4995,7 +5013,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "sR" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -5007,7 +5025,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "sU" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5019,7 +5037,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "sX" = (
 /obj/structure/bed/chair/padded/red{
 	dir = 8;
@@ -5076,7 +5094,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "tc" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -5093,7 +5111,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "te" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -5137,7 +5155,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "ti" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5154,7 +5172,7 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "tj" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5166,7 +5184,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "tk" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5200,7 +5218,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "tp" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -5284,7 +5302,7 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "tJ" = (
 /obj/structure/catwalk,
 /turf/space,
@@ -5304,7 +5322,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "tM" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fourthdeck/aft)
@@ -5337,7 +5355,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "tU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5348,7 +5366,7 @@
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "tV" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -5440,14 +5458,14 @@
 	sort_type = "Primary Tool Storage"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "ue" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "uf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -5461,7 +5479,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "ug" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -5469,7 +5487,7 @@
 	},
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "uh" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5480,7 +5498,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "ui" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -5497,7 +5515,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "uj" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 1
@@ -5506,7 +5524,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "uk" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -5535,7 +5553,7 @@
 	},
 /obj/structure/closet/walllocker/skinsuit,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "uo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5547,7 +5565,7 @@
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "uq" = (
 /obj/machinery/door/blast/shutters{
 	dir = 4;
@@ -5633,7 +5651,7 @@
 	name = "Hangar Maintenance"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "uH" = (
 /obj/effect/floor_decal/corner/brown,
 /obj/structure/cable{
@@ -5644,7 +5662,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "uI" = (
 /obj/machinery/button/blast_door{
 	id_tag = "qm_warehouse2";
@@ -5672,7 +5690,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "uL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -5790,16 +5808,16 @@
 	req_access = list(list("ACCESS_CARGO","ACCESS_MINING"))
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "vk" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
-/obj/structure/table/steel,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "vm" = (
@@ -5816,7 +5834,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "vn" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5829,7 +5847,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "vo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -5960,7 +5978,7 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "vB" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5978,13 +5996,13 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "vC" = (
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "vD" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/fourthdeck/aft)
@@ -6016,7 +6034,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "vK" = (
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/map_preset/tan,
@@ -6045,7 +6063,7 @@
 	},
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "wb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6080,7 +6098,7 @@
 	},
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "we" = (
 /obj/structure/sign/directions/engineering{
 	dir = 1;
@@ -6092,7 +6110,7 @@
 	},
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "wg" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/monotile,
@@ -6138,7 +6156,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "wt" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/waterstore)
@@ -6184,7 +6202,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "wD" = (
 /obj/machinery/light{
 	dir = 4
@@ -6193,7 +6211,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "wE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6224,7 +6242,7 @@
 	sort_type = "Security Checkpoint - Deck 4"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "wH" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6238,7 +6256,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "wI" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -6368,7 +6386,7 @@
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "xr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6385,7 +6403,7 @@
 	pixel_x = 21
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "xu" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -6437,7 +6455,7 @@
 /obj/structure/closet/emcloset/torch,
 /obj/random/maintenance/solgov/clean,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "xL" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6465,7 +6483,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "xR" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6478,7 +6496,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "xS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -6491,7 +6509,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "xT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6508,7 +6526,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "xU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -6524,7 +6542,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "xV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6539,7 +6557,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "xW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6555,7 +6573,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "xX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6574,7 +6592,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "xY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -6587,7 +6605,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "xZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -6598,7 +6616,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "ya" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -6619,7 +6637,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "yc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -6631,7 +6649,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "yd" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6646,7 +6664,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "ye" = (
 /obj/effect/floor_decal/corner/red/half{
 	dir = 8
@@ -6748,7 +6766,7 @@
 /area/maintenance/fourthdeck/forestarboard)
 "yC" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "yD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing/mapped{
@@ -6756,14 +6774,14 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "yF" = (
 /obj/structure/sign/deck/fourth{
 	dir = 8;
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "yG" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -6778,7 +6796,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "yN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -6862,7 +6880,7 @@
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zn" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6874,7 +6892,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6894,7 +6912,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "zq" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6909,7 +6927,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zr" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6920,7 +6938,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zs" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6934,7 +6952,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zt" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6947,7 +6965,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zu" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6960,7 +6978,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zv" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6971,7 +6989,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zx" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/port)
@@ -6982,7 +7000,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6999,7 +7017,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zA" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -7011,7 +7029,7 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "zC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -7096,7 +7114,7 @@
 	pixel_x = 21
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Aa" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 8;
@@ -7113,7 +7131,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Ad" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -7140,7 +7158,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Ag" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -7287,7 +7305,7 @@
 	name = "Fore Port Docking Access"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "AL" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/structure/cable/green{
@@ -7299,7 +7317,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "AM" = (
 /obj/random/trash,
 /obj/structure/catwalk,
@@ -7354,13 +7372,13 @@
 /obj/structure/closet/bombcloset,
 /obj/item/latexballon,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Ba" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/open,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Bf" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -7386,11 +7404,11 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Bo" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Bs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -7516,7 +7534,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "BS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -7524,7 +7542,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "BT" = (
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plating,
@@ -7588,7 +7606,7 @@
 /obj/random/firstaid,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Cg" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -7732,7 +7750,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "CU" = (
 /obj/structure/table/steel,
 /obj/item/frame/fire_alarm,
@@ -7818,7 +7836,6 @@
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
 	},
-/obj/structure/table/steel,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -7826,6 +7843,7 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "Dl" = (
@@ -7862,7 +7880,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Dx" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 6
@@ -7945,7 +7963,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "DP" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -8055,7 +8073,7 @@
 	pixel_x = 40
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Eo" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -8076,7 +8094,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Eq" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -8098,7 +8116,7 @@
 "Er" = (
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Et" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/monotile,
@@ -8167,13 +8185,13 @@
 	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "EI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "EJ" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -8318,7 +8336,7 @@
 	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Fl" = (
 /obj/structure/rack,
 /obj/random/tech_supply,
@@ -8355,7 +8373,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Fo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -8366,7 +8384,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Fp" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -8511,7 +8529,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "FS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -8525,7 +8543,7 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "FV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8562,7 +8580,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Ga" = (
 /turf/simulated/open,
 /area/quartermaster/hangar/top)
@@ -8714,7 +8732,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Gv" = (
 /obj/machinery/door/airlock/external/escapepod{
 	icon_state = "closed";
@@ -8723,7 +8741,7 @@
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Gw" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 4;
@@ -8749,7 +8767,7 @@
 	tag_interior_door = "skipjack_shuttle_dock_inner"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "GC" = (
 /obj/machinery/constructable_frame/computerframe,
 /turf/simulated/floor/plating,
@@ -8835,7 +8853,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "GW" = (
 /turf/simulated/wall/map_preset/tan,
 /area/maintenance/fourthdeck/port)
@@ -8866,7 +8884,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Hg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -8880,7 +8898,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Hm" = (
 /obj/structure/cable{
 	icon_state = "16-0"
@@ -8906,7 +8924,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Ho" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
@@ -8916,7 +8934,7 @@
 	name = "Docking Port Airlock"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Hp" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/vacant/monitoring)
@@ -8966,7 +8984,7 @@
 "HE" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "HF" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -9047,7 +9065,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "HS" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -9063,7 +9081,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "HU" = (
 /obj/machinery/status_display{
 	pixel_x = 32
@@ -9192,7 +9210,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Im" = (
 /obj/structure/hygiene/sink{
 	dir = 1;
@@ -9219,7 +9237,7 @@
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Iq" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
@@ -9324,7 +9342,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "IC" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -9487,7 +9505,7 @@
 /area/maintenance/fourthdeck/port)
 "Jt" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Jx" = (
 /obj/machinery/light{
 	dir = 8
@@ -9503,7 +9521,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Jy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/firealarm{
@@ -9516,7 +9534,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "JA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -9529,7 +9547,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "JD" = (
 /obj/effect/wallframe_spawn/no_grille,
 /obj/effect/paint_stripe/command,
@@ -9604,7 +9622,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "JP" = (
 /obj/effect/floor_decal/corner/red/half{
 	dir = 8
@@ -9634,7 +9652,7 @@
 	tag_interior_door = "rescue_shuttle_dock_inner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "JQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
@@ -9651,7 +9669,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "JR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -9665,7 +9683,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "JS" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9737,7 +9755,7 @@
 	name = "Docking Port Airlock"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Ki" = (
 /obj/structure/rack{
 	dir = 8
@@ -9757,7 +9775,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Kl" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -9852,7 +9870,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "KD" = (
 /obj/machinery/fabricator,
 /obj/effect/floor_decal/corner/brown/half,
@@ -9890,7 +9908,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "KH" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -9963,7 +9981,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "KU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -9975,7 +9993,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "KW" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -10007,7 +10025,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Lf" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -10136,7 +10154,7 @@
 /area/quartermaster/deckchief)
 "LA" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "LB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	level = 2
@@ -10198,7 +10216,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "LK" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -10288,7 +10306,7 @@
 	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "LV" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/supply,
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
@@ -10353,7 +10371,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Mh" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
@@ -10416,7 +10434,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Mo" = (
 /obj/effect/wallframe_spawn/no_grille,
 /obj/machinery/door/firedoor,
@@ -10445,7 +10463,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Mt" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -10499,7 +10517,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "My" = (
 /obj/effect/floor_decal/corner/brown/mono,
 /obj/machinery/alarm{
@@ -10520,7 +10538,7 @@
 "MB" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "MC" = (
 /obj/structure/railing/mapped,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10564,7 +10582,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "MJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -10593,14 +10611,14 @@
 /area/crew_quarters/lounge)
 "MR" = (
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "MT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "MU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/no_grille,
@@ -10613,7 +10631,7 @@
 	name = "Hangar Maintenance"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "MY" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -10669,7 +10687,7 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/open,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Ng" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -10702,7 +10720,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Nl" = (
 /obj/effect/floor_decal/corner/brown/mono,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10827,7 +10845,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Nw" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/box/donut,
@@ -10870,7 +10888,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "NC" = (
 /obj/structure/table/woodentable,
 /obj/item/flashlight/lamp/green,
@@ -10909,7 +10927,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "NQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -10953,7 +10971,7 @@
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/effect/paint/tan,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "NX" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10980,7 +10998,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "NZ" = (
 /obj/machinery/light_switch{
 	pixel_x = -24
@@ -11093,7 +11111,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Ow" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11141,7 +11159,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/open,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "OJ" = (
 /obj/machinery/computer/modular/preset/security{
 	dir = 1;
@@ -11216,7 +11234,7 @@
 "OT" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "OU" = (
 /obj/structure/sign/directions/engineering{
 	dir = 1;
@@ -11246,7 +11264,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "OX" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/r_wall/prepainted,
@@ -11275,7 +11293,7 @@
 	pixel_x = 40
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Pe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11420,7 +11438,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Pw" = (
 /obj/effect/paint_stripe/science,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -11434,7 +11452,7 @@
 	id_tag = "rescue_shuttle_dock_pump"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Pz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -11443,7 +11461,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "PB" = (
 /obj/structure/railing/mapped,
 /turf/simulated/open,
@@ -11503,7 +11521,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "PJ" = (
 /obj/effect/paint_stripe/common,
 /turf/simulated/wall/map_preset/tan,
@@ -11581,7 +11599,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "PT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -11642,7 +11660,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Qc" = (
 /obj/structure/table/steel,
 /obj/random/junk,
@@ -11790,7 +11808,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "QD" = (
 /obj/effect/floor_decal/corner/brown/half,
 /obj/structure/filingcabinet,
@@ -11861,7 +11879,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "QR" = (
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/sortjunction{
@@ -11875,7 +11893,7 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "QU" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -11932,7 +11950,7 @@
 	},
 /obj/machinery/computer/modular/preset/supply_public,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Rf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11985,7 +12003,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Ro" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/closet/secure_closet/personal,
@@ -12021,7 +12039,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Rs" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -12044,7 +12062,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Rv" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -12073,7 +12091,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Ry" = (
 /obj/structure/sign/directions/bridge{
 	dir = 1;
@@ -12154,7 +12172,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "RM" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -12187,7 +12205,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "RP" = (
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -12204,7 +12222,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "RS" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -12229,7 +12247,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "RV" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/bar_coffee/full{
@@ -12243,7 +12261,7 @@
 "RW" = (
 /obj/effect/floor_decal/corner/brown/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "RY" = (
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
@@ -12278,7 +12296,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Sf" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/modular/preset/civilian{
@@ -12328,7 +12346,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Sj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -12421,11 +12439,11 @@
 "Su" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Sv" = (
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Sw" = (
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -12521,7 +12539,7 @@
 	},
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "SG" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -12569,14 +12587,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "SM" = (
 /obj/structure/sign/deck/fourth{
 	dir = 4;
 	pixel_x = -32
 	},
 /turf/simulated/open,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "SO" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -12591,7 +12609,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "SP" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -12668,7 +12686,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "SV" = (
 /obj/structure/closet,
 /obj/random/maintenance/solgov,
@@ -12708,7 +12726,7 @@
 "SY" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "SZ" = (
 /obj/machinery/door/window/northright,
 /obj/effect/floor_decal/corner/research/three_quarters{
@@ -12741,7 +12759,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Tb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -12755,7 +12773,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Tf" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -12873,7 +12891,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "TB" = (
 /obj/random/maintenance/solgov/clean,
 /obj/machinery/light,
@@ -12915,7 +12933,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "TJ" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -12939,7 +12957,7 @@
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "TO" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -12993,7 +13011,7 @@
 /obj/machinery/shield_diffuser,
 /obj/effect/shuttle_landmark/admin/out,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "TY" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
@@ -13018,7 +13036,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Uh" = (
 /obj/effect/floor_decal/corner/brown/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13063,7 +13081,7 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Un" = (
 /obj/structure/fitness/weightlifter,
 /turf/simulated/floor/tiled/dark,
@@ -13089,14 +13107,14 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "Uq" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "Ur" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -13125,7 +13143,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Ux" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Lounge Maintenance"
@@ -13161,7 +13179,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "UA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13215,7 +13233,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "UI" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -13269,7 +13287,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "UO" = (
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -13297,7 +13315,7 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "US" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
 	dir = 4;
@@ -13315,7 +13333,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "UT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -13328,7 +13346,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "UV" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -13353,7 +13371,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "UZ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13366,7 +13384,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Va" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13393,7 +13411,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Vf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -13402,7 +13420,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Vh" = (
 /obj/item/chems/glass/bucket,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13418,7 +13436,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Vj" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -13519,7 +13537,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "VB" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13604,7 +13622,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "VL" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -13614,11 +13632,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "VN" = (
 /obj/structure/sign/iseo,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "VQ" = (
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -13742,7 +13760,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Wm" = (
 /obj/effect/floor_decal/corner/green/mono,
 /obj/structure/disposalpipe/segment,
@@ -13750,13 +13768,13 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Wn" = (
 /obj/effect/wallframe_spawn/no_grille,
 /obj/effect/paint_stripe/supply,
 /obj/effect/paint_stripe/supply,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Wp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -13858,7 +13876,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "WD" = (
 /obj/structure/synthesized_instrument/synthesizer/minimoog,
 /obj/item/radio/intercom/entertainment{
@@ -13891,7 +13909,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "WI" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/shuttle_ceiling/air,
@@ -13948,14 +13966,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "WS" = (
 /obj/effect/floor_decal/corner/brown/half,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "WU" = (
 /turf/simulated/floor/tiled/dark,
 /area/vacant/marine_bay)
@@ -13974,7 +13992,7 @@
 "WX" = (
 /obj/effect/floor_decal/corner/green/mono,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "WY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -13982,13 +14000,13 @@
 /area/maintenance/fourthdeck/port)
 "WZ" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Xc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Xd" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -14089,7 +14107,7 @@
 /area/maintenance/fourthdeck/forestarboard)
 "Xn" = (
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Xo" = (
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/corner/mauve/half{
@@ -14100,7 +14118,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "Xr" = (
 /obj/effect/floor_decal/corner/brown/half,
 /obj/item/radio/intercom{
@@ -14138,7 +14156,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Xw" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -14163,7 +14181,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "XA" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -14335,7 +14353,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "XW" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/bar_soft/full,
@@ -14394,7 +14412,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Yb" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
 	dir = 8
@@ -14427,7 +14445,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/hull,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Yk" = (
 /turf/simulated/floor/tiled/monotile,
 /area/maintenance/fourthdeck/forestarboard)
@@ -14440,7 +14458,7 @@
 /area/maintenance/fourthdeck/foreport)
 "Ym" = (
 /turf/simulated/open,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Yp" = (
 /obj/random/trash,
 /turf/simulated/floor/tiled/dark,
@@ -14502,14 +14520,14 @@
 	name = "Escape Pod One"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Yx" = (
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
 /turf/simulated/open,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Yy" = (
 /obj/effect/floor_decal/corner/brown/half,
 /obj/structure/cable/green,
@@ -14518,7 +14536,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/fourthdeck/center)
+/area/hallway/fourthdeck/center)
 "Yz" = (
 /obj/structure/disposalpipe/sortjunction/untagged/flipped,
 /obj/effect/floor_decal/industrial/warning{
@@ -14554,7 +14572,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "YC" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -14612,7 +14630,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "YI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -14627,13 +14645,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "YK" = (
 /obj/structure/sign/warning/docking_area{
 	dir = 1
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "YN" = (
 /obj/effect/paint_stripe/common,
 /turf/simulated/wall/prepainted,
@@ -14660,7 +14678,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "YS" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -14676,7 +14694,7 @@
 /area/quartermaster/office)
 "YU" = (
 /turf/simulated/wall/prepainted,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "YV" = (
 /obj/machinery/computer/modular/preset/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -14768,7 +14786,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Zd" = (
 /turf/simulated/wall/map_preset/tan,
 /area/vacant/marine_bay)
@@ -14799,7 +14817,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 "Zk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14866,7 +14884,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "Zo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14984,7 +15002,7 @@
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "ZB" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -15001,7 +15019,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "ZE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/railing/mapped{
@@ -15009,7 +15027,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "ZF" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -15117,7 +15135,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "ZQ" = (
 /obj/effect/floor_decal/corner/brown/half,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15140,7 +15158,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "ZU" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15148,7 +15166,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
-/area/hallway/primary/fourthdeck/aft)
+/area/hallway/fourthdeck/aft)
 "ZV" = (
 /obj/item/stool/bar/padded,
 /turf/simulated/floor/carpet,
@@ -15189,7 +15207,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/fourthdeck/fore)
+/area/hallway/fourthdeck/fore)
 
 (1,1,1) = {"
 Gt
@@ -24783,7 +24801,7 @@ ng
 ot
 vW
 Jn
-sn
+rw
 tP
 tS
 Vp

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -113,7 +113,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "az" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/thirddeck/aftport)
@@ -221,7 +221,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "bd" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/thruster/d3starboard)
@@ -244,7 +244,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "bg" = (
 /obj/structure/sign/directions/bridge{
 	dir = 1;
@@ -715,7 +715,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ch" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
@@ -805,7 +805,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "cx" = (
 /obj/machinery/telecomms/bus/preset_one,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1078,7 +1078,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "cU" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -1111,7 +1111,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "cW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -1371,13 +1371,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "dC" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "dD" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/starboard)
@@ -1481,7 +1481,7 @@
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1749,7 +1749,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "eB" = (
 /obj/machinery/light{
 	dir = 1;
@@ -2183,7 +2183,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ft" = (
 /obj/effect/floor_decal/corner/green/mono,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -2226,7 +2226,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "fD" = (
 /obj/item/storage/secure/safe{
 	pixel_x = 32
@@ -2814,7 +2814,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "gG" = (
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/plating,
@@ -2945,7 +2945,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "gV" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	injecting = 1;
@@ -3280,7 +3280,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/open,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "hM" = (
 /obj/machinery/light,
 /obj/machinery/photocopier,
@@ -3327,7 +3327,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "hV" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/design_database,
@@ -3514,7 +3514,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "ir" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 8
@@ -3664,7 +3664,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/green/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "iJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3857,7 +3857,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "jf" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 4
@@ -3890,7 +3890,7 @@
 "ji" = (
 /obj/effect/floor_decal/corner/green/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "jk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3916,7 +3916,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "jn" = (
 /obj/structure/bed/chair/padded/red{
 	dir = 1;
@@ -4514,7 +4514,7 @@
 /area/maintenance/thirddeck/forestarboard)
 "kK" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "kN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4574,7 +4574,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "kT" = (
 /obj/structure/sign/directions/bridge{
 	dir = 1;
@@ -4651,7 +4651,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ld" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 8
@@ -4789,7 +4789,7 @@
 /area/maintenance/thirddeck/forestarboard)
 "lu" = (
 /turf/unsimulated/mask,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "lv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4876,7 +4876,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "lK" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -4990,7 +4990,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5008,7 +5008,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "mc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -5128,7 +5128,7 @@
 /area/maintenance/thirddeck/forestarboard)
 "mj" = (
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "mk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5138,7 +5138,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "mm" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5214,7 +5214,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "mF" = (
 /obj/machinery/appliance/cooker/fryer,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -5275,7 +5275,7 @@
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "mT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -5292,7 +5292,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "mU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -5305,7 +5305,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "mV" = (
 /obj/machinery/light{
 	dir = 4
@@ -5319,7 +5319,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "mW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5339,7 +5339,7 @@
 /area/maintenance/thirddeck/forestarboard)
 "mX" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "mY" = (
 /obj/structure/sign/directions/bridge{
 	dir = 1;
@@ -5352,7 +5352,7 @@
 	pixel_y = -5
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "mZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5361,13 +5361,13 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "na" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/corner/green/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "nc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -5478,7 +5478,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ny" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ladder,
@@ -5599,7 +5599,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "nQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5619,7 +5619,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "nR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5635,7 +5635,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "nS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5653,7 +5653,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "nT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5670,7 +5670,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "nU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5747,7 +5747,7 @@
 "oa" = (
 /obj/structure/stairs/west,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "ob" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 8
@@ -5755,7 +5755,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "oc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -5768,7 +5768,7 @@
 	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "od" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5777,7 +5777,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "oe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -5790,7 +5790,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "og" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -5853,7 +5853,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ot" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -5880,7 +5880,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ow" = (
 /obj/machinery/door/airlock/external/bolted{
 	id_tag = "3rd_starboard_ext"
@@ -5901,7 +5901,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "oz" = (
 /obj/structure/bed/chair/padded/red{
 	dir = 8
@@ -5974,7 +5974,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "oM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -5986,7 +5986,7 @@
 	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "oO" = (
 /obj/structure/table/gamblingtable,
 /obj/item/dice/d20,
@@ -6014,7 +6014,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/open,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "oU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -6027,7 +6027,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "oV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -6038,7 +6038,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "oW" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Stairwell";
@@ -6052,7 +6052,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "oX" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -6068,7 +6068,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "oY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -6225,7 +6225,7 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "po" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6241,7 +6241,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "pp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6262,7 +6262,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "pr" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6281,7 +6281,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "ps" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
@@ -6366,7 +6366,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "pG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6379,7 +6379,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "pH" = (
 /obj/structure/flora/pottedplant/flower,
 /obj/item/radio/intercom/entertainment{
@@ -6423,7 +6423,7 @@
 /area/crew_quarters/recreation)
 "pO" = (
 /turf/simulated/open,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "pP" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{
@@ -6434,7 +6434,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "pQ" = (
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -6457,10 +6457,10 @@
 	pixel_y = 3
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "pT" = (
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "pU" = (
 /obj/structure/sign/directions/infirmary{
 	dir = 1;
@@ -6473,7 +6473,7 @@
 /obj/effect/paint_stripe/common,
 /obj/effect/paint_stripe/common,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "pX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/freezer,
@@ -6510,7 +6510,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "qg" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/binary/pump/on,
@@ -6598,7 +6598,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "qs" = (
 /obj/structure/table/woodentable,
 /obj/item/chems/drinks/glass2/coffeecup,
@@ -6610,7 +6610,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "qt" = (
 /obj/effect/floor_decal/corner/lime/three_quarters{
 	dir = 1
@@ -6619,7 +6619,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "qu" = (
 /turf/simulated/floor/carpet,
 /area/crew_quarters/recreation)
@@ -6691,7 +6691,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "qM" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/valve/shutoff,
@@ -6727,14 +6727,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "qQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "qR" = (
 /obj/structure/table/woodentable/walnut,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -6750,7 +6750,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "qU" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -6765,7 +6765,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "qV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -6795,7 +6795,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ra" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -6806,7 +6806,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rb" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6818,7 +6818,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "rc" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -6830,7 +6830,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "re" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -6838,13 +6838,13 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rf" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rh" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6861,7 +6861,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ri" = (
 /obj/machinery/light{
 	dir = 1
@@ -6870,7 +6870,7 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -6886,7 +6886,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rl" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -6898,12 +6898,12 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rp" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rq" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -6922,7 +6922,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "rr" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -6936,7 +6936,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rt" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 1
@@ -6947,7 +6947,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ru" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -6956,7 +6956,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rv" = (
 /obj/effect/paint_stripe/common,
 /turf/simulated/wall/map_preset/tan,
@@ -6975,7 +6975,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ry" = (
 /obj/structure/lectern/walnut,
 /obj/effect/floor_decal/spline/fancy/black{
@@ -7015,7 +7015,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "rC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7097,7 +7097,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "rS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
@@ -7111,7 +7111,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "rT" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -7154,7 +7154,7 @@
 	},
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "sd" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "3rd_port";
@@ -7188,7 +7188,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "sf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7209,7 +7209,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "sg" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7227,7 +7227,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "sh" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7243,7 +7243,7 @@
 	},
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "si" = (
 /obj/structure/rack{
 	dir = 8
@@ -7268,7 +7268,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "sk" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7282,7 +7282,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "sl" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7306,7 +7306,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "sn" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7324,7 +7324,7 @@
 	sort_type = "Cryogenic Storage"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "so" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -7345,7 +7345,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "sp" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7361,7 +7361,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "sq" = (
 /obj/machinery/appliance/cooker/stove,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -7384,7 +7384,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "st" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -7407,7 +7407,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sv" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7422,7 +7422,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sw" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7438,7 +7438,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sx" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/emcloset/torch,
@@ -7459,7 +7459,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7468,7 +7468,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sA" = (
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/ship_munition/disperser_charge/emp,
@@ -7488,7 +7488,7 @@
 /obj/effect/paint_stripe/common,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sC" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7504,7 +7504,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sE" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -7520,7 +7520,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7536,7 +7536,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sG" = (
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment{
@@ -7555,7 +7555,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sH" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7592,7 +7592,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sL" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7613,7 +7613,7 @@
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "sP" = (
 /obj/structure/rack{
 	dir = 8
@@ -7662,7 +7662,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -7680,10 +7680,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sW" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sX" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -7692,7 +7692,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "sY" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
@@ -7729,7 +7729,7 @@
 	},
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ti" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techfloor,
@@ -7746,7 +7746,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "tn" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -7760,7 +7760,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "ts" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7773,12 +7773,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "tt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tu" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 8
@@ -7803,7 +7803,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -7812,7 +7812,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tx" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Lift";
@@ -7826,26 +7826,26 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tz" = (
 /obj/effect/floor_decal/corner/green/three_quarters{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "tA" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "tC" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -7858,7 +7858,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tE" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -7869,7 +7869,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tF" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -7903,7 +7903,7 @@
 "tI" = (
 /obj/effect/floor_decal/corner/green/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -7915,7 +7915,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tL" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -7924,7 +7924,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tM" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -7964,7 +7964,7 @@
 "tP" = (
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tQ" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
@@ -7993,7 +7993,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "tT" = (
 /obj/structure/closet/medical_wall/filled{
 	pixel_x = -32
@@ -8022,11 +8022,11 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "tX" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "tY" = (
 /obj/machinery/status_display,
 /obj/effect/paint/eggshell,
@@ -8058,7 +8058,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ub" = (
 /turf/simulated/wall/walnut,
 /area/vacant/cabin)
@@ -8071,7 +8071,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "uf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -8129,7 +8129,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ul" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -8139,14 +8139,14 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "um" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "uo" = (
 /obj/effect/floor_decal/corner/lime/three_quarters{
 	dir = 4
@@ -8157,7 +8157,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "up" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -8186,7 +8186,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "us" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	dir = 8;
@@ -8216,13 +8216,13 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "ux" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "uy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light/small{
@@ -8281,7 +8281,7 @@
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "uK" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ship_munition/disperser_charge/mining,
@@ -8296,7 +8296,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "uN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8479,7 +8479,7 @@
 "vp" = (
 /obj/effect/paint_stripe/common,
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "vs" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -8504,7 +8504,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "vx" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -8532,7 +8532,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "vD" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -8559,7 +8559,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "vG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -8568,7 +8568,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "vI" = (
 /obj/item/beach_ball,
 /obj/effect/floor_decal/stairs{
@@ -8751,7 +8751,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "wk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -8761,10 +8761,10 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "wl" = (
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "wm" = (
 /obj/random_multi/single_item/poppy,
 /turf/simulated/floor/tiled/techfloor,
@@ -8916,7 +8916,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "wJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8933,7 +8933,7 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "wL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8946,7 +8946,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "wM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8962,7 +8962,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "wN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8974,7 +8974,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "wO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8993,7 +8993,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "wP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9006,7 +9006,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "wQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9022,7 +9022,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "wR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9035,7 +9035,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "wV" = (
 /obj/structure/sign/deck/third{
 	dir = 1;
@@ -9045,7 +9045,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "wW" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -9118,7 +9118,7 @@
 	},
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "xh" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -9141,7 +9141,7 @@
 	},
 /obj/effect/paint/tan,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "xk" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/reagent_dispensers/fueltank,
@@ -9153,7 +9153,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/open,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "xm" = (
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
@@ -9270,7 +9270,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "xF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -9293,7 +9293,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "xJ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9306,7 +9306,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "xM" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9320,7 +9320,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "xN" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9333,7 +9333,7 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "xO" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -9355,7 +9355,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "xQ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9367,14 +9367,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "xR" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "xS" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -9387,7 +9387,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "xT" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9400,7 +9400,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "xU" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -9453,7 +9453,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "xY" = (
 /obj/effect/paint_stripe/common,
 /turf/simulated/wall/map_preset/tan,
@@ -9548,7 +9548,7 @@
 	},
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "yn" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 4
@@ -9578,7 +9578,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "yq" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -9625,7 +9625,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "yB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -9923,7 +9923,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "zr" = (
 /obj/machinery/light{
 	dir = 8;
@@ -10008,7 +10008,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "zG" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/crew_quarters/cryolocker)
@@ -10053,7 +10053,7 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "zR" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/ladder,
@@ -10373,7 +10373,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "AS" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1
@@ -10670,7 +10670,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "Cc" = (
 /obj/structure/table,
 /turf/simulated/floor/tiled/dark,
@@ -11154,7 +11154,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "Dv" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin{
@@ -11235,7 +11235,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "DH" = (
 /obj/effect/paint_stripe/common,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -11506,13 +11506,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Em" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "En" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -11705,7 +11705,7 @@
 /area/maintenance/thirddeck/port)
 "EM" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "EN" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -11797,7 +11797,7 @@
 "EX" = (
 /obj/effect/paint_stripe/common,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "Fa" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -12155,7 +12155,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "Gd" = (
 /obj/effect/floor_decal/corner/green/half,
 /obj/structure/cable/green{
@@ -12377,7 +12377,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "GD" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -12415,7 +12415,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "GI" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/cargo)
@@ -12656,7 +12656,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Hr" = (
 /obj/structure/sign/warning/hot_exhaust{
 	dir = 8
@@ -12721,7 +12721,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "HD" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12775,7 +12775,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "HS" = (
 /obj/structure/bed/chair/armchair/beige{
 	dir = 8
@@ -12809,7 +12809,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Il" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12834,7 +12834,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "Is" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -12970,7 +12970,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "IS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13013,7 +13013,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "IW" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13048,7 +13048,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "IZ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13058,7 +13058,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "Ja" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13079,7 +13079,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13095,14 +13095,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Jc" = (
 /obj/effect/floor_decal/corner/green,
 /obj/machinery/atmospherics/valve/shutoff{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "Jd" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -13112,7 +13112,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "Je" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -13120,7 +13120,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Jg" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -13386,7 +13386,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "JK" = (
 /obj/effect/floor_decal/corner/lime/mono,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13400,7 +13400,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "JL" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -13439,7 +13439,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "JP" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -13450,7 +13450,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "JQ" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1
@@ -13462,7 +13462,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "JR" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13692,7 +13692,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Ku" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -13836,7 +13836,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Lk" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -13890,7 +13890,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Lx" = (
 /obj/machinery/light/spot{
 	dir = 8
@@ -13906,7 +13906,7 @@
 	},
 /obj/effect/floor_decal/corner/green/half,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Lz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13935,7 +13935,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "LE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
@@ -14075,7 +14075,7 @@
 "Mi" = (
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Mj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -14222,7 +14222,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "MC" = (
 /obj/machinery/appliance/cooker/oven,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -14238,7 +14238,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "MG" = (
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/thirddeck)
@@ -14250,7 +14250,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "MI" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -14271,7 +14271,7 @@
 /area/maintenance/thirddeck/starboard)
 "MM" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "MN" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -14386,7 +14386,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Nj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -14413,7 +14413,7 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "No" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -14521,7 +14521,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "NB" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -14545,7 +14545,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "NF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian{
@@ -14889,7 +14889,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "OL" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1;
@@ -14955,7 +14955,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "OZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15009,7 +15009,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "Pg" = (
 /obj/structure/closet/secure_closet/chaplain,
 /turf/simulated/floor/carpet/purple,
@@ -15062,7 +15062,7 @@
 "Pr" = (
 /obj/structure/stairs/south,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Ps" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/bed/chair{
@@ -15198,7 +15198,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "PU" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -15210,7 +15210,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "PV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15218,7 +15218,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "PW" = (
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/machinery/atmospherics/binary/pump/high_power/on/max_pressure{
@@ -15231,7 +15231,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "PY" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/structure/disposalpipe/segment{
@@ -15373,7 +15373,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Qu" = (
 /obj/machinery/door/blast/shutters{
 	dir = 4;
@@ -15441,7 +15441,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "QG" = (
 /obj/effect/floor_decal/corner/blue/three_quarters,
 /obj/machinery/alarm{
@@ -15467,7 +15467,7 @@
 "QJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "QK" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -15744,7 +15744,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "RD" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -15794,7 +15794,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "RN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -15819,7 +15819,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "RS" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	injecting = 1;
@@ -15863,7 +15863,7 @@
 	},
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "Sf" = (
 /obj/structure/fitness/punchingbag,
 /turf/simulated/floor/wood,
@@ -15982,7 +15982,7 @@
 	},
 /obj/effect/paint/tan,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Sv" = (
 /turf/simulated/floor/carpet/blue,
 /area/storage/service)
@@ -16028,7 +16028,7 @@
 /obj/effect/wallframe_spawn/no_grille,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "SG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16251,7 +16251,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "To" = (
 /obj/effect/wallframe_spawn/reinforced_borosilicate,
 /obj/machinery/atmospherics/binary/passive_gate/on{
@@ -16274,7 +16274,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "Tr" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark,
@@ -16312,7 +16312,7 @@
 	},
 /obj/effect/paint/tan,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Tv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16364,11 +16364,11 @@
 "TC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "TD" = (
 /obj/effect/paint_stripe/common,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "TE" = (
 /turf/simulated/wall/map_preset/tan,
 /area/chapel/office)
@@ -16568,7 +16568,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "Up" = (
 /turf/simulated/floor/tiled/dark,
 /area/engineering/hardstorage)
@@ -16603,7 +16603,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "Ut" = (
 /obj/structure/table/steel,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16801,7 +16801,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "UX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -16837,7 +16837,7 @@
 	},
 /obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "Vc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -16913,7 +16913,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "Vm" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -16937,7 +16937,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Vo" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -17009,7 +17009,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Vz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/meter,
@@ -17038,7 +17038,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "VD" = (
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1
@@ -17057,7 +17057,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "VF" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
@@ -17070,7 +17070,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "VH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -17100,7 +17100,7 @@
 "VK" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "VL" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -17127,7 +17127,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "VR" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/machinery/door/firedoor,
@@ -17149,7 +17149,7 @@
 /area/crew_quarters/mess)
 "VU" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "VV" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
@@ -17172,7 +17172,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "VY" = (
 /obj/structure/stairs/west,
 /obj/effect/floor_decal/corner/yellow/half{
@@ -17204,7 +17204,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Wi" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -17286,7 +17286,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "WE" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -17433,7 +17433,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "WZ" = (
 /obj/structure/disposalpipe/down{
 	dir = 8
@@ -17526,7 +17526,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "Xo" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -17574,7 +17574,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Xx" = (
 /obj/structure/table,
 /obj/structure/closet/walllocker/skinsuit,
@@ -17697,7 +17697,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "XR" = (
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cryolocker)
@@ -17760,7 +17760,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "XY" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -17931,7 +17931,7 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "YK" = (
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
@@ -17970,10 +17970,10 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "YQ" = (
 /turf/simulated/open,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "YR" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -17990,7 +17990,7 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "YT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -18010,7 +18010,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "YV" = (
 /obj/item/stool,
 /turf/simulated/floor/tiled/techfloor,
@@ -18018,7 +18018,7 @@
 "YW" = (
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "YX" = (
 /obj/structure/sign/warning/hot_exhaust{
 	dir = 8
@@ -18035,7 +18035,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/thirddeck/center)
 "YZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Tool Storage Maintenance"
@@ -18116,7 +18116,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/thirddeck/fore)
+/area/hallway/thirddeck/fore)
 "Zp" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -18176,7 +18176,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "Zx" = (
 /obj/structure/table/marble,
 /obj/machinery/appliance/mixer/candy{
@@ -18243,7 +18243,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/aft)
+/area/hallway/thirddeck/aft)
 "ZH" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1486,7 +1486,7 @@
 /obj/structure/bed/roller,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "do" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/rack,
@@ -2598,7 +2598,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "fR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2614,7 +2614,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "fT" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/space)
@@ -2642,7 +2642,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "fW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -2697,7 +2697,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "gg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2720,7 +2720,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2737,10 +2737,10 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "gi" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "gj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2791,13 +2791,13 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "gn" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "gp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2816,7 +2816,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "gs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2959,7 +2959,7 @@
 "gD" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "gE" = (
 /obj/structure/sign/warning/radioactive,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -3082,7 +3082,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "gV" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -3382,7 +3382,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "hP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector{
@@ -3494,7 +3494,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "ie" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 4
@@ -3774,7 +3774,7 @@
 	icon_state = "bulb1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "iN" = (
 /obj/effect/paint_stripe/engineering,
 /turf/simulated/wall/map_preset/tan,
@@ -3871,7 +3871,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "iY" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -3980,7 +3980,7 @@
 /area/maintenance/seconddeck/forestarboard)
 "jp" = (
 /turf/unsimulated/mask,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "jq" = (
 /obj/effect/shuttle_landmark/lift/robotics_bottom,
 /turf/simulated/floor/plating,
@@ -4423,7 +4423,7 @@
 	tag_door = "escape_pod_11_berth_hatch"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "kB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -4434,7 +4434,7 @@
 /area/engineering/foyer)
 "kD" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "kE" = (
 /obj/structure/table,
 /turf/simulated/floor/tiled/dark,
@@ -4522,7 +4522,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "kP" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -4701,7 +4701,7 @@
 	pixel_z = 10
 	},
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "lp" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -4722,7 +4722,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "lq" = (
 /obj/structure/railing/mapped,
 /obj/machinery/light{
@@ -4730,7 +4730,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/open,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "ls" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -4814,7 +4814,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "lE" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -5025,7 +5025,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "mj" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
@@ -5041,7 +5041,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "mk" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -5049,7 +5049,7 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/open,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "mo" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -5087,7 +5087,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "ms" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
@@ -5327,18 +5327,18 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "mY" = (
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "mZ" = (
 /obj/structure/stairs/east,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "na" = (
 /obj/structure/sign/directions/supply{
 	pixel_z = -10
@@ -5349,7 +5349,7 @@
 	pixel_z = 10
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "nb" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -5435,7 +5435,7 @@
 	icon_state = "warningcorner"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "nl" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cable/green{
@@ -5475,7 +5475,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "no" = (
 /obj/machinery/ftl_shunt/core,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -5734,7 +5734,7 @@
 	pixel_z = 6
 	},
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "nQ" = (
 /obj/structure/sign/directions/security{
 	pixel_y = -7
@@ -5744,7 +5744,7 @@
 	pixel_z = 6
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "nT" = (
 /obj/structure/sign/directions/infirmary{
 	dir = 1;
@@ -5754,7 +5754,7 @@
 	pixel_z = 6
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "nW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -5774,7 +5774,7 @@
 	},
 /obj/machinery/door/airlock/glass/research,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "ob" = (
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
@@ -5918,7 +5918,7 @@
 "oy" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "oz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/structure/cable/cyan{
@@ -6066,7 +6066,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "pb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -6180,7 +6180,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "ps" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -6319,12 +6319,12 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "pJ" = (
 /obj/item/radio/beacon,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "pK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6342,7 +6342,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "pL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6357,7 +6357,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "pM" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -6373,7 +6373,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "pO" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -6655,7 +6655,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "qn" = (
 /obj/effect/paint_stripe/engineering,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -6669,7 +6669,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "qp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -7153,7 +7153,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "rn" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7169,7 +7169,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "rq" = (
 /obj/structure/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -7196,7 +7196,7 @@
 	pixel_y = 25
 	},
 /turf/simulated/open,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "rt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
@@ -7308,7 +7308,7 @@
 	},
 /obj/structure/closet/emcloset/torch,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "rM" = (
 /obj/machinery/atmospherics/valve/digital/open,
 /turf/simulated/floor/tiled/techfloor,
@@ -7323,7 +7323,7 @@
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "rP" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/maintenance/disposal)
@@ -7356,13 +7356,13 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "rW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "rX" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -7685,7 +7685,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "sU" = (
 /obj/structure/sign/directions/infirmary{
 	dir = 1;
@@ -7813,7 +7813,7 @@
 /obj/random/junk,
 /obj/random/junk,
 /turf/simulated/floor/tiled/techfloor,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "tk" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -9240,7 +9240,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "wU" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/maintenance/seconddeck/aftport)
@@ -9359,7 +9359,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "xl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 6
@@ -9514,7 +9514,7 @@
 /area/assembly/robotics/surgery)
 "xR" = (
 /turf/simulated/floor/tiled/techfloor,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "xS" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -9525,7 +9525,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "xT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/tiled/techfloor,
@@ -9718,7 +9718,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "yy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -9861,7 +9861,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "yQ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
@@ -10355,7 +10355,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "An" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -10377,7 +10377,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Ao" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 6
@@ -10543,7 +10543,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "AK" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Locker Room"
@@ -10923,7 +10923,7 @@
 /area/engineering/foyer)
 "BY" = (
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Cb" = (
 /obj/structure/sign/warning/compressed_gas{
 	dir = 8
@@ -11094,7 +11094,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Cz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
@@ -11181,7 +11181,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "CM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -11288,7 +11288,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Da" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11300,7 +11300,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Db" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -11370,7 +11370,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Dk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/light/small{
@@ -12116,7 +12116,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "Fn" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -12493,7 +12493,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "Gn" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -12509,7 +12509,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Go" = (
 /obj/structure/window/reinforced,
 /obj/machinery/portable_atmospherics/canister/hydrogen,
@@ -12541,7 +12541,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Gv" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -12862,7 +12862,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Ho" = (
 /obj/machinery/computer/air_control{
 	dir = 8;
@@ -13208,13 +13208,13 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "In" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Io" = (
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/engineering{
@@ -13292,7 +13292,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "IB" = (
 /obj/machinery/door/airlock/glass/engineering{
 	name = "Engine Control Room"
@@ -13402,7 +13402,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "IW" = (
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -13512,7 +13512,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Jj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -13549,7 +13549,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Jo" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 6
@@ -13617,7 +13617,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "Jv" = (
 /obj/structure/closet/secure_closet/engineering_senior,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -13635,7 +13635,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "JB" = (
 /obj/effect/wallframe_spawn/reinforced_borosilicate,
 /obj/machinery/door/blast/regular/open{
@@ -13684,7 +13684,7 @@
 /obj/structure/closet/secure_closet/crew,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "JJ" = (
 /obj/item/stool/padded,
 /obj/machinery/light/small{
@@ -13699,7 +13699,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "JM" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -13860,7 +13860,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Kn" = (
 /obj/structure/lattice,
 /obj/structure/railing/mapped{
@@ -13872,7 +13872,7 @@
 	dir = 8
 	},
 /turf/simulated/open,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Ko" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/camera/network/engineering{
@@ -13899,7 +13899,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Kt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13910,7 +13910,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Ku" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -14056,7 +14056,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "La" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -14066,7 +14066,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Lb" = (
 /obj/effect/shuttle_landmark/ninja/deck3{
 	name = "2nd Deck, Aft Starboard"
@@ -14126,7 +14126,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Li" = (
 /turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
@@ -14166,7 +14166,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Ln" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -14339,7 +14339,7 @@
 "LT" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "LW" = (
 /obj/machinery/atmospherics/binary/circulator{
 	anchored = 1;
@@ -14564,7 +14564,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Mx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
@@ -14794,7 +14794,7 @@
 	pixel_z = 6
 	},
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "Nl" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -14946,7 +14946,7 @@
 	},
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "NH" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -15199,7 +15199,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "On" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
@@ -15225,7 +15225,7 @@
 	pixel_x = -44
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Ot" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/engineering_torch,
@@ -15367,7 +15367,7 @@
 	name = "Xenobiology Access"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "OL" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/techfloor/orange{
@@ -15401,7 +15401,7 @@
 	},
 /obj/structure/closet/secure_closet/crew/research,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "OR" = (
 /obj/effect/paint_stripe/engineering,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -15421,7 +15421,7 @@
 /area/engineering/atmos)
 "OV" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "OW" = (
 /obj/effect/paint_stripe/engineering,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -15440,7 +15440,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Pa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15565,7 +15565,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Pn" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
 	dir = 8;
@@ -15679,7 +15679,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "PG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 4
@@ -15695,7 +15695,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "PI" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -15968,7 +15968,7 @@
 	level = 2
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "Qu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -16111,7 +16111,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "QN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
@@ -16422,7 +16422,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "RL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor,
@@ -16683,7 +16683,7 @@
 /area/engineering/engineering_monitoring)
 "Ss" = (
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "Sv" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -16700,7 +16700,7 @@
 	},
 /obj/structure/closet/walllocker/skinsuit,
 /turf/simulated/floor/tiled/techfloor,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Sz" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -16743,7 +16743,7 @@
 /area/engineering/engineering_bay)
 "SD" = (
 /turf/simulated/open,
-/area/hallway/primary/seconddeck/center)
+/area/hallway/seconddeck/center)
 "SE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -16817,7 +16817,7 @@
 "SO" = (
 /obj/structure/closet/walllocker/skinsuit,
 /turf/simulated/floor/tiled/techfloor,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "SP" = (
 /obj/machinery/light{
 	dir = 8
@@ -16854,7 +16854,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "SW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -16891,7 +16891,7 @@
 	},
 /obj/machinery/door/airlock,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/seconddeck/elevator)
+/area/hallway/seconddeck/elevator)
 "Ta" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -17013,7 +17013,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Tu" = (
 /obj/machinery/space_heater,
 /obj/machinery/alarm{
@@ -17037,7 +17037,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Tx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -17061,7 +17061,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "TD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/acid{
@@ -17395,7 +17395,7 @@
 	pixel_x = 26
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "UQ" = (
 /obj/structure/rack{
 	dir = 8
@@ -17630,7 +17630,7 @@
 /area/assembly/robotics/surgery)
 "VK" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "VL" = (
 /obj/structure/sign/warning/radioactive{
 	dir = 4
@@ -17644,7 +17644,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "VP" = (
 /obj/structure/closet/radiation,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -17664,7 +17664,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "VT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -17731,7 +17731,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Wg" = (
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/reinforced/airless,
@@ -17753,7 +17753,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Wj" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	dir = 1;
@@ -17833,7 +17833,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Ws" = (
 /obj/machinery/computer/modular/preset/engineering{
 	dir = 4
@@ -17871,7 +17871,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Wy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -17880,7 +17880,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "Wz" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -18304,7 +18304,7 @@
 /area/maintenance/seconddeck/foreport)
 "XA" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "XB" = (
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -18807,7 +18807,7 @@
 "Zt" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/seconddeck/fore)
+/area/hallway/seconddeck/fore)
 "Zu" = (
 /obj/effect/paint_stripe/medical,
 /turf/simulated/wall/prepainted,
@@ -18951,7 +18951,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/seconddeck)
+/area/hallway/seconddeck)
 "ZT" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/floor_decal/industrial/warning{

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -18641,6 +18641,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/machinery/nuclear_cylinder_storage/prefilled{
+	req_access = list("ACCESS_VAULT")
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/nuke_storage)
 "mXb" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -36,7 +36,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aai" = (
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Hallway - Lift";
@@ -48,7 +48,7 @@
 	},
 /obj/effect/floor_decal/corner/green/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aaj" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Auxiliary Head"
@@ -430,7 +430,7 @@
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "abJ" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -1172,7 +1172,7 @@
 	},
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ady" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1413,7 +1413,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aed" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -1763,9 +1763,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/glass/medical{
-	autoset_access = 0;
 	name = "Medical Foyer";
-	req_access = list(list("ACCESS_MEDICAL","ACCESS_MORGUE","ACCESS_FORENSICS"))
+	req_access = null
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,
@@ -2353,8 +2352,11 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/staging)
 "afI" = (
-/turf/simulated/wall/prepainted,
-/area/hallway/primary/firstdeck/fore)
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/firstdeck/fore)
 "afK" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -3212,7 +3214,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "ahJ" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/flashlight/lamp/green,
@@ -3714,7 +3716,7 @@
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "aiX" = (
 /obj/random/junk,
 /obj/structure/railing/mapped{
@@ -3904,7 +3906,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "ajZ" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/r_wall/prepainted,
@@ -4103,7 +4105,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "akX" = (
 /obj/effect/paint_stripe/science,
 /turf/simulated/wall/map_preset/tan,
@@ -4699,7 +4701,7 @@
 /obj/machinery/door/airlock/hatch/maintenance,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "apk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4771,7 +4773,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aqa" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4779,7 +4781,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aqb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
@@ -4791,20 +4793,20 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aqd" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aqg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aqh" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -4813,12 +4815,12 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aqi" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aqk" = (
 /obj/machinery/atm{
 	pixel_y = 32
@@ -4830,7 +4832,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aql" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/item/radio/intercom{
@@ -4840,7 +4842,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aqm" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4851,10 +4853,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aqn" = (
 /turf/unsimulated/mask,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aqp" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 4
@@ -4963,7 +4965,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "arn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4980,7 +4982,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "art" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5000,7 +5002,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aru" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5018,7 +5020,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "arx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -5033,7 +5035,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "ary" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5054,7 +5056,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "arA" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
@@ -5115,7 +5117,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "asv" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -5144,7 +5146,7 @@
 /area/security/brig)
 "asy" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "asA" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/bo)
@@ -5157,7 +5159,7 @@
 	pixel_z = 3
 	},
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "asD" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5169,7 +5171,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "asE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -5197,7 +5199,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "asK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -5327,7 +5329,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "atB" = (
 /obj/machinery/lapvend,
 /obj/structure/window/reinforced{
@@ -5337,16 +5339,16 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "atC" = (
 /obj/structure/stairs/west,
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "atD" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "atF" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5359,7 +5361,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "atG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -5447,10 +5449,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "auk" = (
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "auy" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5465,7 +5467,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "auB" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -5493,7 +5495,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "auF" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5510,7 +5512,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "auG" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5528,7 +5530,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "auH" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5544,7 +5546,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "auI" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5566,7 +5568,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "auJ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5583,7 +5585,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "auL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5594,14 +5596,14 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "auM" = (
 /obj/structure/sign/warning/pods/south,
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "auN" = (
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "auO" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5732,7 +5734,7 @@
 	},
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "avy" = (
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -5742,7 +5744,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "avI" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/structure/table/steel,
@@ -5750,7 +5752,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "avO" = (
 /obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/body_scanconsole{
@@ -5771,7 +5773,7 @@
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "avT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -5786,7 +5788,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "avU" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -5797,7 +5799,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/open,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "avV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -5807,7 +5809,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "avW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -5815,7 +5817,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "avX" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5827,7 +5829,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "avZ" = (
 /obj/structure/sign/directions/evac{
 	pixel_y = 3
@@ -5836,10 +5838,10 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "awa" = (
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "awb" = (
 /obj/structure/sign/directions/infirmary{
 	dir = 4;
@@ -5852,7 +5854,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "awc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5862,13 +5864,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/green/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "awd" = (
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/corner/green/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "awG" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5882,14 +5884,14 @@
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "awH" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "awM" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
@@ -5898,7 +5900,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "awV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -5909,7 +5911,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "awX" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/r_wall/prepainted,
@@ -5930,7 +5932,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "axa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
@@ -5938,14 +5940,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "axc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "axd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5957,7 +5959,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "axi" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -5966,7 +5968,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "axl" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5992,7 +5994,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "axy" = (
 /obj/structure/sign/directions/medical{
 	pixel_y = 32
@@ -6001,7 +6003,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "axB" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
@@ -6010,7 +6012,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "axD" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -6024,7 +6026,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "axF" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6033,7 +6035,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "axH" = (
 /obj/machinery/door/window/southright{
 	dir = 1;
@@ -6069,7 +6071,7 @@
 	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "axN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed/chair/office/light{
@@ -6118,20 +6120,20 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "axZ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aya" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ayb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6144,7 +6146,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ayd" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6155,7 +6157,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aye" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6168,7 +6170,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ayf" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6187,7 +6189,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ayg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6203,7 +6205,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ayh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -6220,7 +6222,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ayi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6233,7 +6235,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ayj" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6250,7 +6252,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aym" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6266,7 +6268,7 @@
 	},
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ayp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -6283,7 +6285,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ayw" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6301,7 +6303,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ayy" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6317,7 +6319,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ayz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6334,7 +6336,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ayA" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 4
@@ -6361,7 +6363,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ayC" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -6380,7 +6382,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ayG" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -6399,7 +6401,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ayH" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/beacon,
@@ -6415,7 +6417,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ayP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6433,7 +6435,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "azi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6443,14 +6445,14 @@
 /obj/effect/floor_decal/corner/green/mono,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "azm" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "azn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -6461,7 +6463,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "azq" = (
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
@@ -6471,7 +6473,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "azN" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -6480,7 +6482,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "azR" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6493,14 +6495,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "azS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "azT" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -6508,7 +6510,7 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "azV" = (
 /obj/effect/shuttle_landmark/ert/deck2{
 	name = "1st Deck, Fore Port"
@@ -6521,7 +6523,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "aAe" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -6530,7 +6532,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "aAl" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6542,7 +6544,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aAm" = (
 /turf/simulated/wall/map_preset/tan,
 /area/crew_quarters/head/aux)
@@ -6563,7 +6565,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "aAI" = (
 /obj/structure/bed/chair/office/comfy/red,
 /obj/machinery/button/windowtint{
@@ -6612,18 +6614,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "aAV" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "aBd" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint_stripe/security,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "aBq" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/rack{
@@ -6652,13 +6654,13 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aBx" = (
 /obj/structure/sign/warning/pods/south{
 	dir = 1
 	},
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aBy" = (
 /obj/machinery/artifact_scanpad,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -6791,14 +6793,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "aCr" = (
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "aCu" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -6836,7 +6838,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aCF" = (
 /obj/structure/rack{
 	dir = 8
@@ -6957,7 +6959,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "aDD" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7025,7 +7027,7 @@
 /obj/effect/catwalk_plated,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aDL" = (
 /obj/effect/paint_stripe/command,
 /obj/effect/paint_stripe/command,
@@ -7039,7 +7041,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "aDP" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7055,7 +7057,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aDU" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7163,7 +7165,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aEP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7180,7 +7182,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aEU" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -7199,7 +7201,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aEW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7215,7 +7217,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aEY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -7232,7 +7234,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aEZ" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -7245,7 +7247,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aFb" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -7376,25 +7378,25 @@
 	pixel_y = -23
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aFV" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "aFW" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aFX" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aGb" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -7404,7 +7406,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aGe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -7413,14 +7415,14 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aGf" = (
 /obj/machinery/light,
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aGh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -7432,7 +7434,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aGi" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -7441,7 +7443,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aGo" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7586,7 +7588,7 @@
 "aGY" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "aGZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8338,7 +8340,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "aKH" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/prepainted,
@@ -10627,7 +10629,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "aWn" = (
 /obj/effect/shuttle_landmark/ninja/deck2{
 	name = "1st Deck, Aft Port"
@@ -10659,7 +10661,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "baH" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -11008,7 +11010,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "bBt" = (
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -11049,7 +11051,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "bGb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -11088,7 +11090,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "bIb" = (
 /obj/effect/shuttle_landmark/escape_pod/start/pod13,
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -11330,7 +11332,7 @@
 /area/shuttle/escape_pod16/station)
 "bUH" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "bUZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11402,7 +11404,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "bXb" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -11426,14 +11428,14 @@
 "bZb" = (
 /obj/machinery/cryopod{
 	dir = 1;
-	icon_state = "body_scanner_0"
+	icon_state = "open"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod15/station)
 "cab" = (
 /obj/machinery/cryopod{
 	dir = 1;
-	icon_state = "body_scanner_0"
+	icon_state = "open"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod16/station)
@@ -11445,7 +11447,7 @@
 "cbb" = (
 /obj/machinery/cryopod{
 	dir = 1;
-	icon_state = "body_scanner_0"
+	icon_state = "open"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod17/station)
@@ -11475,7 +11477,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ceb" = (
 /obj/effect/shuttle_landmark/escape_pod/start/pod17,
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -11501,7 +11503,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "chb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techfloor,
@@ -11550,7 +11552,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "ckb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -11822,7 +11824,7 @@
 	name = "Privacy Shutters"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "cEb" = (
 /obj/structure/closet/secure_closet/medical_torch,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -11972,7 +11974,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "cQb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -12107,7 +12109,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "dab" = (
 /obj/structure/table,
 /obj/structure/sign/warning/nosmoking_1{
@@ -12314,7 +12316,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "dkV" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -12503,7 +12505,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "dDb" = (
 /obj/effect/paint/eggshell,
 /obj/effect/paint_stripe/medical,
@@ -12516,7 +12518,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "dEb" = (
 /obj/random/torchcloset,
 /turf/simulated/floor/tiled/techfloor,
@@ -12591,7 +12593,7 @@
 /area/medical/morgue/autopsy)
 "dJp" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "dJY" = (
 /obj/structure/sign/warning/hot_exhaust{
 	dir = 1
@@ -12682,7 +12684,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "dNb" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/alarm{
@@ -12716,7 +12718,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "dQb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -12744,7 +12746,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "dRs" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -12925,7 +12927,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "edb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13084,7 +13086,7 @@
 /obj/effect/floor_decal/corner/research/half,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "erb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -13162,7 +13164,7 @@
 	},
 /obj/structure/closet/emcloset/torch,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "exb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -13412,7 +13414,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "eVQ" = (
 /turf/simulated/floor/tiled,
 /area/security/brig)
@@ -13498,7 +13500,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "fmb" = (
 /obj/structure/closet/secure_closet/medical_torch,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -13509,7 +13511,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "fnR" = (
 /obj/structure/closet/crate,
 /obj/item/grenade/chem_grenade/metalfoam,
@@ -13702,7 +13704,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "fDR" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13773,7 +13775,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "fLK" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/space)
@@ -13852,7 +13854,7 @@
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "fUK" = (
 /obj/machinery/shieldwallgen,
 /obj/effect/floor_decal/techfloor{
@@ -13972,7 +13974,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ghb" = (
 /obj/structure/iv_drip,
 /obj/effect/floor_decal/floordetail/edgedrain{
@@ -14004,7 +14006,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "gib" = (
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
@@ -14098,7 +14100,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "gta" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -14108,7 +14110,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "guP" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/regular{
@@ -14160,7 +14162,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "gyj" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
@@ -14223,7 +14225,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "gAv" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/firstdeck/centralstarboard)
@@ -14236,7 +14238,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "gDb" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -14377,7 +14379,7 @@
 "gTR" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "gUp" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -14390,7 +14392,7 @@
 	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "gUu" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/machinery/door/firedoor,
@@ -14483,13 +14485,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "hdb" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "heb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -14505,7 +14507,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "hfb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -14521,7 +14523,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "hfA" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/tan,
@@ -14547,7 +14549,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "hgt" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -14596,7 +14598,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "hhm" = (
 /obj/structure/table,
 /obj/item/scanner/spectrometer/adv,
@@ -14625,7 +14627,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "hjk" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/item/radio/headset,
@@ -14666,7 +14668,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "hqb" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -14737,7 +14739,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "htq" = (
 /obj/machinery/light{
 	dir = 8
@@ -14758,7 +14760,7 @@
 	},
 /obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "huf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -14849,7 +14851,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "hzb" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -14959,7 +14961,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "hEU" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -14985,7 +14987,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "hFk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -15070,7 +15072,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "hNW" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -15158,17 +15160,17 @@
 	},
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "hVb" = (
 /obj/item/stool/padded,
 /obj/effect/floor_decal/corner/research{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "hVG" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "hVH" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -15177,7 +15179,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "hWb" = (
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -15207,7 +15209,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "hYX" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -15265,7 +15267,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "ihc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/blast/regular{
@@ -15277,7 +15279,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "iib" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -15350,7 +15352,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "imK" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -15429,7 +15431,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "itb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
@@ -15499,7 +15501,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ixf" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -15564,14 +15566,14 @@
 	},
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "iCj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "iCS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -15821,7 +15823,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "iTP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15841,7 +15843,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "iVb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -15850,7 +15852,7 @@
 /obj/effect/floor_decal/industrial/shutoff,
 /obj/machinery/atmospherics/valve/shutoff,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "iVM" = (
 /obj/machinery/light{
 	dir = 1;
@@ -15868,7 +15870,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "iZb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -15878,13 +15880,13 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "iZg" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "jab" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -15897,7 +15899,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/research/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "jbk" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -16002,7 +16004,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "jhf" = (
 /obj/structure/table/steel,
 /obj/machinery/light_switch{
@@ -16118,7 +16120,7 @@
 "jkv" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "jlb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16127,7 +16129,7 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "jmf" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16152,7 +16154,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "jpt" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -16185,7 +16187,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "jtb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -16262,7 +16264,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "jyb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16314,7 +16316,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "jBW" = (
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
@@ -16603,7 +16605,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "jZb" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "misc_lab"
@@ -16674,7 +16676,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "kep" = (
 /obj/structure/table,
 /obj/machinery/alarm{
@@ -16772,7 +16774,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "knb" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
@@ -16796,7 +16798,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "kpb" = (
 /obj/machinery/reagentgrinder,
 /obj/item/chems/glass/beaker/large,
@@ -16847,7 +16849,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "kss" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -16994,7 +16996,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "kHb" = (
 /obj/structure/bed/padded,
 /obj/effect/floor_decal/corner/pink/mono,
@@ -17380,7 +17382,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "lgb" = (
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck Hallway - Auxiliary Cryogenic Storage"
@@ -17398,7 +17400,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "lgd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17429,7 +17431,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "ljb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -17438,7 +17440,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "lkn" = (
 /obj/structure/disposaloutlet,
 /obj/structure/lattice,
@@ -17522,7 +17524,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ltb" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/design_console,
@@ -17551,7 +17553,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "luq" = (
 /obj/structure/table/steel,
 /obj/item/hand_labeler,
@@ -17654,7 +17656,7 @@
 	},
 /obj/effect/floor_decal/corner/research/three_quarters,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "lym" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -17820,7 +17822,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "lKb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -18025,7 +18027,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "mib" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18041,7 +18043,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "miG" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled,
@@ -18063,7 +18065,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "mjt" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -18088,7 +18090,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "mlb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -18160,7 +18162,7 @@
 	},
 /obj/machinery/atmospherics/valve/shutoff,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "mpy" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/maintenance/firstdeck/aftstarboard)
@@ -18238,7 +18240,7 @@
 	sort_type = "Robotics"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "mvE" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -18421,7 +18423,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "mGb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -18493,7 +18495,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "mLd" = (
 /obj/structure/dispenser,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -18521,7 +18523,7 @@
 "mMX" = (
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "mNb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18556,7 +18558,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "mTb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -18713,14 +18715,14 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "nct" = (
 /obj/structure/closet/crate,
 /obj/item/chems/glass/beaker/vial/random/toxin,
 /obj/item/chems/glass/beaker/vial/random/toxin,
 /obj/item/chems/drinks/juicebox/sensible_random,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "ncX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -18786,7 +18788,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "njb" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -18850,7 +18852,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "nkz" = (
 /obj/structure/sign/warning/airlock{
 	dir = 1
@@ -18945,7 +18947,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "nub" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
@@ -18984,7 +18986,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "nys" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 8
@@ -19128,7 +19130,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "nIb" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -19160,7 +19162,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "nLd" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -19173,7 +19175,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "nLo" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -19269,10 +19271,10 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "nSb" = (
 /turf/simulated/open,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "nUp" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -19286,7 +19288,7 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "nVe" = (
 /obj/abstract/landmark{
 	name = "JoinLateCyborg"
@@ -19322,7 +19324,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "nWl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -19331,7 +19333,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "nXk" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/assembly,
@@ -19358,7 +19360,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "nZb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19376,7 +19378,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "nZm" = (
 /obj/structure/rack,
 /obj/random/maintenance/solgov,
@@ -19411,7 +19413,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "oby" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable/green{
@@ -19435,7 +19437,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "ocb" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/corner/red{
@@ -19483,7 +19485,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "oeb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -19529,7 +19531,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "ohl" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -19568,7 +19570,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "okp" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/r_wall/prepainted,
@@ -19597,7 +19599,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "opg" = (
 /obj/effect/wallframe_spawn/reinforced_borosilicate,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -19753,7 +19755,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "oAx" = (
 /obj/structure/sign/warning/pods/south{
 	dir = 1
@@ -19850,7 +19852,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "oIb" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/detectives_office)
@@ -20369,7 +20371,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "pmI" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/structure/rack{
@@ -20779,7 +20781,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "pIW" = (
 /obj/machinery/meter/turf,
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -20962,7 +20964,7 @@
 "pUr" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "pWb" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -21055,7 +21057,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "qab" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	icon_state = "map_injector";
@@ -21216,7 +21218,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "qjb" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/machinery/light{
@@ -21358,7 +21360,7 @@
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "qxb" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -21620,7 +21622,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "qHx" = (
 /obj/structure/sign/warning/secure_area,
 /obj/effect/paint_stripe/command,
@@ -21669,7 +21671,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "qKU" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -22011,7 +22013,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "rdb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -22260,7 +22262,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "rtb" = (
 /obj/structure/table,
 /obj/structure/sign/warning/fire{
@@ -22316,13 +22318,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ruS" = (
 /obj/effect/floor_decal/corner/green/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset/torch,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "rvb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -22333,7 +22335,7 @@
 "rvY" = (
 /obj/effect/floor_decal/corner/research,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "rwb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -22548,7 +22550,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "rKP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -22626,7 +22628,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "rPb" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -22805,7 +22807,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "sab" = (
 /obj/effect/floor_decal/corner/research/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -23157,7 +23159,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "snJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -23237,7 +23239,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ssr" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -23330,7 +23332,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/paint_stripe/security,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "sxT" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/l3closet/security,
@@ -23452,13 +23454,13 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "sEm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "sFb" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -23607,7 +23609,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "sNQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23791,7 +23793,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "tiQ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/rack,
@@ -24216,7 +24218,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "ugk" = (
 /obj/effect/paint_stripe/security,
 /obj/effect/paint_stripe/security,
@@ -24267,7 +24269,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "umT" = (
 /obj/effect/floor_decal/spline/plain/blue{
 	dir = 4
@@ -24282,7 +24284,7 @@
 "uoC" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "urd" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -24296,7 +24298,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "usV" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -24439,7 +24441,7 @@
 "uJn" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "uKa" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -24476,7 +24478,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "uPf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plating,
@@ -24612,7 +24614,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "uZY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/bed/chair/padded/red{
@@ -24746,7 +24748,7 @@
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "vBV" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
@@ -24819,7 +24821,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "vIn" = (
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/disposalpipe/segment,
@@ -24922,7 +24924,7 @@
 "vTY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "vUl" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -24978,7 +24980,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "wdX" = (
 /obj/effect/paint/eggshell,
 /obj/effect/paint_stripe/science,
@@ -25039,7 +25041,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "wlw" = (
 /obj/machinery/sparker{
 	id_tag = "Isocell3";
@@ -25110,7 +25112,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "wrB" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Primary Emergency Storage - Port";
@@ -25204,13 +25206,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "wzN" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "wAK" = (
 /obj/machinery/door/airlock/civilian{
 	autoset_access = 0;
@@ -25298,7 +25300,7 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/open,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "wNx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25380,7 +25382,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "wXc" = (
 /obj/item/radio/intercom/entertainment{
 	dir = 4;
@@ -25506,7 +25508,7 @@
 /obj/random/trash,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/fore)
+/area/maintenance/firstdeck/forestarboard)
 "xoo" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -25537,7 +25539,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "xpu" = (
 /obj/machinery/atmospherics/unary/heater,
 /obj/machinery/light{
@@ -25702,7 +25704,7 @@
 	},
 /obj/machinery/door/airlock/glass/civilian,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "xEq" = (
 /obj/structure/sign/warning/pods/south,
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -25760,7 +25762,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/fore)
+/area/hallway/firstdeck/fore)
 "xJY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/radiation,
@@ -25779,7 +25781,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "xKY" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -25848,7 +25850,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/fore)
+/area/security/lobby)
 "xRm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -25883,7 +25885,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "xSU" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -25937,7 +25939,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/firstdeck/center)
+/area/hallway/firstdeck/center)
 "yeI" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/r_wall/prepainted,
@@ -25958,7 +25960,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/firstdeck/aft)
+/area/hallway/firstdeck/aft)
 "yii" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -36785,14 +36787,14 @@ acr
 adf
 adU
 aeI
-afI
+kXS
 hUM
 nct
 vAw
 jkv
 xmT
 hUM
-afI
+kXS
 qwk
 ieP
 ksj
@@ -37819,7 +37821,7 @@ oyb
 aXb
 aXb
 obZ
-aFV
+afI
 xoo
 aIg
 aJw
@@ -38021,7 +38023,7 @@ osb
 aXb
 aXb
 obZ
-aFV
+afI
 bSz
 sTT
 xCn
@@ -38627,7 +38629,7 @@ nub
 nEb
 aAT
 aEU
-aFV
+afI
 aGP
 aIj
 aJA
@@ -38829,7 +38831,7 @@ auB
 mlw
 iui
 wkS
-aFV
+afI
 aGP
 aIk
 aJB
@@ -39016,7 +39018,7 @@ aiY
 pXG
 vMm
 jkm
-afI
+kXS
 iZg
 xDX
 qHq
@@ -39435,7 +39437,7 @@ aAT
 eZQ
 fVw
 obZ
-aFV
+afI
 aGP
 aIm
 aJE

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -7922,7 +7922,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/emitter/anchored,
+/obj/machinery/power/emitter/anchored{
+	req_access = list("ACCESS_RESEARCH")
+	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -5750,7 +5750,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "avO" = (
 /obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/body_scanconsole{
@@ -6069,7 +6069,7 @@
 	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "axN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed/chair/office/light{
@@ -6433,7 +6433,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "azi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6521,7 +6521,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "aAe" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -6530,7 +6530,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "aAl" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6623,7 +6623,7 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint_stripe/security,
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "aBq" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/rack{
@@ -11330,7 +11330,7 @@
 /area/shuttle/escape_pod16/station)
 "bUH" = (
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "bUZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11369,12 +11369,6 @@
 /obj/structure/bed/chair/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod17/station)
-"bVw" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/security/lobby)
 "bVA" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -11828,7 +11822,7 @@
 	name = "Privacy Shutters"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "cEb" = (
 /obj/structure/closet/secure_closet/medical_torch,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -12722,7 +12716,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "dQb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -14104,7 +14098,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "gta" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -14383,7 +14377,7 @@
 "gTR" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/r_wall/prepainted,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "gUp" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -14396,7 +14390,7 @@
 	icon_state = "chair_preview"
 	},
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "gUu" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
 /obj/machinery/door/firedoor,
@@ -15283,7 +15277,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "iib" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -15435,7 +15429,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "itb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
@@ -17826,7 +17820,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "lKb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -19179,7 +19173,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "nLo" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -20968,7 +20962,7 @@
 "pUr" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "pWb" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
@@ -23336,7 +23330,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/paint_stripe/security,
 /turf/simulated/floor/plating,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "sxT" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/l3closet/security,
@@ -24445,7 +24439,7 @@
 "uJn" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "uKa" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -24928,7 +24922,7 @@
 "vTY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "vUl" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -25854,7 +25848,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/security/lobby)
+/area/hallway/primary/firstdeck/fore)
 "xRm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -36002,7 +35996,7 @@ nLd
 vTY
 vTY
 lJP
-bVw
+aFV
 aBd
 uJn
 aDF
@@ -36204,7 +36198,7 @@ dPA
 bUH
 bUH
 grI
-bVw
+aFV
 aBd
 uJn
 hQT

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -156,7 +156,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "aA" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4
@@ -327,7 +327,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "aW" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -345,7 +345,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "aX" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 10
@@ -356,7 +356,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "aY" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 5
@@ -414,7 +414,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "bc" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -583,7 +583,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "bx" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -687,7 +687,7 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "bK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -696,7 +696,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "bL" = (
 /obj/machinery/light{
 	dir = 8
@@ -759,7 +759,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "bY" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 4
@@ -853,7 +853,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "ch" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Bridge Substation Bypass"
@@ -1007,7 +1007,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "ct" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1165,7 +1165,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "cI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -1345,7 +1345,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "da" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 6
@@ -1415,7 +1415,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "dg" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -1498,7 +1498,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "dq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1512,7 +1512,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "ds" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -1608,7 +1608,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "dJ" = (
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
@@ -1618,7 +1618,7 @@
 	},
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "dP" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
 	id = "meeting_windows"
@@ -1648,7 +1648,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "dR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -1705,7 +1705,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "ed" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1782,7 +1782,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "eq" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -1999,7 +1999,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "eO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -2012,7 +2012,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "eQ" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2032,7 +2032,7 @@
 	},
 /obj/effect/floor_decal/corner/darkblue,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "eT" = (
 /obj/structure/flora/pottedplant/unusual,
 /obj/machinery/light,
@@ -2300,7 +2300,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "fC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -2324,7 +2324,7 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint_stripe/command,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "fE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2392,7 +2392,7 @@
 "fI" = (
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "fJ" = (
 /obj/structure/closet/secure_closet/CO,
 /obj/item/aiModule/freeform,
@@ -2643,7 +2643,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "gc" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/structure/cable/green{
@@ -2665,7 +2665,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "gg" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -2711,7 +2711,7 @@
 	c_tag = "Bridge Hallway - Center Aft Starboard"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "gl" = (
 /obj/effect/shuttle_landmark/torch/deck1/exploration_shuttle{
 	name = "B-Deck, Fore Port"
@@ -2720,7 +2720,7 @@
 /area/space)
 "gm" = (
 /turf/unsimulated/mask,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "go" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -2773,7 +2773,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "gL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2795,7 +2795,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "gM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2808,7 +2808,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "gO" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -2818,7 +2818,7 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "gP" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -2855,7 +2855,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "gS" = (
 /obj/random/maintenance/solgov,
 /obj/random/closet,
@@ -2917,7 +2917,7 @@
 	name = "Bridge EVA External Access"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "gZ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8;
@@ -3003,18 +3003,18 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "hC" = (
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "hE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "hF" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3029,7 +3029,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "hH" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8
@@ -3061,6 +3061,9 @@
 /obj/structure/bed/chair/comfy/red,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
+"hS" = (
+/turf/simulated/wall/r_wall/map_preset/tan,
+/area/bridge)
 "hU" = (
 /obj/structure/table,
 /obj/item/stack/medical/advanced/bruise_pack,
@@ -3095,7 +3098,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "ie" = (
 /obj/machinery/door/airlock/sol{
 	id_tag = "hopdoor";
@@ -3160,11 +3163,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "im" = (
 /obj/structure/railing/mapped,
 /turf/simulated/open,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "in" = (
 /obj/structure/sign/directions/engineering{
 	pixel_z = 10
@@ -3175,7 +3178,7 @@
 	},
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "io" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3186,7 +3189,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "ip" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3235,7 +3238,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "iu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -3308,7 +3311,7 @@
 	},
 /obj/effect/floor_decal/industrial/shutoff,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "iH" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/random/summarydocument/eng,
@@ -3385,7 +3388,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "iV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -3401,7 +3404,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "iW" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -3420,7 +3423,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "iX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3434,7 +3437,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "iY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -3445,7 +3448,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "iZ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3460,7 +3463,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "ja" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -3496,7 +3499,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "jg" = (
 /obj/item/storage/box/donut,
 /obj/structure/table/woodentable/walnut,
@@ -3658,7 +3661,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "jR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
@@ -3671,7 +3674,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "jS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3679,7 +3682,7 @@
 	},
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "jT" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3691,7 +3694,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "jU" = (
 /obj/structure/sign/directions/bridge{
 	dir = 8;
@@ -3702,10 +3705,10 @@
 	},
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "jV" = (
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "jW" = (
 /obj/structure/sign/directions/infirmary{
 	pixel_y = -4
@@ -3715,7 +3718,7 @@
 	},
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "jX" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3853,7 +3856,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "kv" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "bridgesafe_front";
@@ -3907,7 +3910,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "kE" = (
 /obj/structure/lattice,
 /obj/machinery/light/navigation/delay2,
@@ -3944,7 +3947,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "kL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
@@ -3952,7 +3955,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "kM" = (
 /obj/effect/floor_decal/corner/darkblue/half{
 	dir = 1
@@ -3962,14 +3965,14 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "kN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "kO" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3984,7 +3987,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "kP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -3995,7 +3998,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "kQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4004,7 +4007,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "kR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -4017,20 +4020,20 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "kS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "kU" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "kV" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 9
@@ -4042,7 +4045,7 @@
 	},
 /obj/effect/floor_decal/industrial/shutoff,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "kX" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/substation/bridge)
@@ -4135,7 +4138,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "ly" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/cable/green{
@@ -4180,7 +4183,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "lC" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -4201,7 +4204,7 @@
 	sort_type = "Chief Engineer"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "lD" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4218,7 +4221,7 @@
 	},
 /obj/effect/paint_stripe/command,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "lE" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4233,7 +4236,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "lH" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4247,7 +4250,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "lL" = (
 /obj/machinery/door/blast/regular/open{
 	density = 0;
@@ -4272,7 +4275,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "lR" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4288,7 +4291,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "lT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -4326,7 +4329,7 @@
 	req_access = list("ACCESS_TORCH_CREW")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/bridge)
 "lZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/shuttle{
 	id_tag = "perseverance_shuttle_pump"
@@ -4485,7 +4488,7 @@
 /obj/effect/floor_decal/corner/darkblue,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "mS" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4497,7 +4500,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "mT" = (
 /obj/machinery/computer/modular/preset/aislot/sysadmin{
 	dir = 1;
@@ -4521,7 +4524,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "mW" = (
 /obj/machinery/camera/network/bridge{
 	c_tag = "Bridge Hallway - Lift";
@@ -4534,13 +4537,13 @@
 /obj/structure/cable/green,
 /obj/effect/floor_decal/corner/darkblue/half,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "mX" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "mY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -4552,7 +4555,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "mZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -4560,7 +4563,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "na" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4587,7 +4590,7 @@
 	sort_type = "Chief Of Security"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "nc" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 10
@@ -4596,7 +4599,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "nd" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -4771,7 +4774,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "nE" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -4831,7 +4834,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "nN" = (
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/dark,
@@ -4890,7 +4893,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "oc" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4903,7 +4906,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "oe" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -4987,7 +4990,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "ow" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -5058,7 +5061,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "oK" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -5324,7 +5327,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "pT" = (
 /obj/machinery/light{
 	dir = 8
@@ -5489,7 +5492,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "qh" = (
 /obj/structure/bed/chair/comfy/blue,
 /obj/structure/network_cable,
@@ -5532,7 +5535,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "qp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
@@ -5565,7 +5568,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "qu" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -5637,7 +5640,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "qA" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Bridge Exterior - Port";
@@ -5728,7 +5731,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "qW" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -5804,7 +5807,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rb" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
@@ -5820,7 +5823,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rc" = (
 /obj/item/radio/beacon,
 /obj/machinery/alarm{
@@ -5834,7 +5837,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5845,7 +5848,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "re" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -5855,7 +5858,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -5867,7 +5870,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rg" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
@@ -5876,7 +5879,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "ri" = (
 /obj/effect/paint_stripe/security,
 /turf/simulated/wall/r_wall/prepainted,
@@ -5893,7 +5896,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -5902,7 +5905,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rm" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -5912,7 +5915,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rn" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/computer/modular/preset/cardslot/command{
@@ -6109,7 +6112,7 @@
 	},
 /obj/effect/floor_decal/corner/darkblue,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rY" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6121,7 +6124,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "rZ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6133,7 +6136,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "sa" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6143,7 +6146,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "se" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -6158,7 +6161,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "sf" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -6198,7 +6201,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "si" = (
 /obj/structure/table/woodentable_reinforced/ebony/walnut,
 /turf/simulated/floor/wood/walnut,
@@ -6500,7 +6503,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "to" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6992,7 +6995,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "uK" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -7007,7 +7010,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "uM" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/structure/cable/green{
@@ -7046,7 +7049,7 @@
 	},
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "uW" = (
 /obj/machinery/button/access/exterior{
 	id_tag = "bridge_eva_airlock";
@@ -7090,7 +7093,7 @@
 	pixel_x = -21
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "vg" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced/hull,
@@ -7205,7 +7208,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "vy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -7261,7 +7264,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "vH" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/crew,
@@ -7655,7 +7658,7 @@
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "wC" = (
 /obj/item/pen,
 /obj/item/stamp/xo,
@@ -7778,7 +7781,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "xc" = (
 /turf/simulated/wall/prepainted,
 /area/maintenance/bridge/foreport)
@@ -7825,7 +7828,7 @@
 "xi" = (
 /obj/structure/sign/warning/airlock,
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "xj" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -8061,7 +8064,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "xV" = (
 /obj/machinery/alarm{
 	pixel_y = 24
@@ -8077,7 +8080,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "xW" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -8092,7 +8095,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "xX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8105,7 +8108,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "xY" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8115,7 +8118,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "xZ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -8124,7 +8127,7 @@
 	},
 /obj/effect/floor_decal/corner/darkblue/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "yb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -8134,7 +8137,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "yc" = (
 /obj/structure/catwalk,
 /obj/random/junk,
@@ -8366,7 +8369,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "zp" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -8463,7 +8466,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "zM" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/blast/shutters{
@@ -8538,7 +8541,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "zT" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -8574,7 +8577,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Ab" = (
 /obj/effect/shuttle_landmark/ninja/deck1{
 	name = "B-Deck, Aft Port"
@@ -8660,7 +8663,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Aq" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -8676,7 +8679,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Av" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -8712,7 +8715,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "AA" = (
 /obj/effect/floor_decal/corner/red/half{
 	dir = 4
@@ -8805,7 +8808,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "AU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8916,7 +8919,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "By" = (
 /obj/machinery/pointdefense_control{
 	initial_id_tag = "torch_primary_pd";
@@ -9079,7 +9082,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "BY" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9088,7 +9091,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Cb" = (
 /obj/effect/shuttle_landmark/torch/deck1/perseverance{
 	name = "B-Deck, Fore Starboard"
@@ -9195,7 +9198,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Cs" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 6
@@ -9299,7 +9302,7 @@
 /obj/effect/floor_decal/corner/darkblue/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "CE" = (
 /obj/effect/floor_decal/corner/darkblue/three_quarters{
 	dir = 8
@@ -9321,7 +9324,7 @@
 	},
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "CI" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	dir = 4;
@@ -9342,7 +9345,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "CJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -9400,7 +9403,7 @@
 /obj/effect/floor_decal/corner/darkblue/mono,
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "CW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9475,7 +9478,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Dt" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -9498,7 +9501,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Dz" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -9566,7 +9569,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "DT" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9616,7 +9619,7 @@
 "Ec" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Ed" = (
 /obj/structure/bed/chair/wood/wings/mahogany{
 	dir = 8;
@@ -9646,7 +9649,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "En" = (
 /obj/structure/sign/warning/detailed{
 	dir = 1;
@@ -9667,7 +9670,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Eq" = (
 /obj/structure/bed/chair/shuttle/blue{
 	dir = 4;
@@ -9710,7 +9713,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Ez" = (
 /obj/structure/table{
 	name = "plastic table frame"
@@ -9797,7 +9800,7 @@
 	},
 /obj/effect/floor_decal/corner/darkblue/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
@@ -9807,7 +9810,7 @@
 	name = "Bridge EVA Internal Access"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Fd" = (
 /obj/machinery/door/blast/regular/open{
 	density = 0;
@@ -9967,7 +9970,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/darkblue/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "FQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
@@ -9975,7 +9978,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "FS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9990,7 +9993,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "FY" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -10009,7 +10012,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Gb" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -10021,7 +10024,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Gc" = (
 /obj/machinery/door/airlock/external{
 	icon_state = "closed";
@@ -10030,7 +10033,7 @@
 	name = "Bridge EVA Internal Access"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Ge" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -10124,7 +10127,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Gy" = (
 /obj/structure/bed/chair/padded/red{
 	dir = 1;
@@ -10160,7 +10163,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "GI" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -10184,7 +10187,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "GU" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
@@ -10215,7 +10218,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "GX" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 5
@@ -10326,7 +10329,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/bridge/aft)
+/area/bridge)
 "Hh" = (
 /obj/machinery/disposal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10887,7 +10890,7 @@
 /obj/machinery/atmospherics/valve/shutoff,
 /obj/effect/floor_decal/industrial/shutoff,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Jc" = (
 /obj/effect/paint_stripe/engineering,
 /turf/simulated/wall/r_wall/prepainted,
@@ -10923,7 +10926,7 @@
 	req_access = list("ACCESS_TORCH_CREW")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/bridge)
 "Jh" = (
 /obj/structure/bed/chair/comfy/captain{
 	dir = 8
@@ -10984,7 +10987,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Jy" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -11082,7 +11085,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "JT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -11110,7 +11113,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Kc" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable/green{
@@ -11118,7 +11121,7 @@
 	},
 /obj/effect/paint_stripe/command,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/bridge)
 "Kd" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/firealarm{
@@ -11159,7 +11162,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Km" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -11217,7 +11220,7 @@
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/bridge)
 "KB" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Crew Area"
@@ -11298,7 +11301,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "KX" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 9
@@ -11317,7 +11320,7 @@
 	},
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Le" = (
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
@@ -11338,7 +11341,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Lg" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -11357,7 +11360,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/bridge)
 "Lh" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Chief Engineer - Office";
@@ -11400,7 +11403,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Ll" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/disposalpipe/segment{
@@ -11527,7 +11530,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/hallway/primary/bridge/aft)
+/area/bridge)
 "Md" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -11620,7 +11623,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Mq" = (
 /obj/structure/sign/directions/infirmary{
 	pixel_y = -4
@@ -11630,13 +11633,13 @@
 	},
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Mr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Mw" = (
 /obj/effect/floor_decal/corner/darkblue,
 /turf/simulated/floor/tiled/dark,
@@ -11678,7 +11681,7 @@
 /obj/structure/cable/green,
 /obj/effect/paint_stripe/command,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/bridge)
 "Ne" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 6
@@ -11882,7 +11885,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/hallway/primary/bridge/aft)
+/area/bridge)
 "NN" = (
 /obj/machinery/vending/wallmed1{
 	pixel_y = 32;
@@ -11981,7 +11984,7 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Og" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11999,7 +12002,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Oi" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -12021,7 +12024,7 @@
 "Os" = (
 /obj/effect/floor_decal/corner/darkblue/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "OD" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 9
@@ -12142,7 +12145,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Pe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -12158,7 +12161,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Pf" = (
 /obj/effect/floor_decal/corner/darkblue{
 	dir = 10
@@ -12284,7 +12287,7 @@
 /obj/machinery/atmospherics/valve/shutoff,
 /obj/effect/floor_decal/industrial/shutoff,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "PP" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
@@ -12361,7 +12364,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Qf" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
 	dir = 8;
@@ -12407,7 +12410,7 @@
 "Qi" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Qj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12499,7 +12502,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "QV" = (
 /obj/structure/railing/mapped,
 /turf/simulated/open,
@@ -12577,7 +12580,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Rj" = (
 /obj/machinery/button/windowtint{
 	id_tag = "rd_windows";
@@ -12617,7 +12620,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Ro" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -12649,7 +12652,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Rq" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8;
@@ -12688,7 +12691,7 @@
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "RD" = (
 /obj/machinery/light/small,
 /obj/machinery/computer/modular/preset/medical{
@@ -12761,7 +12764,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "RW" = (
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white/monotile,
@@ -12853,7 +12856,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "So" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -12928,7 +12931,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "SP" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -13017,7 +13020,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Tf" = (
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
@@ -13036,7 +13039,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Th" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -13108,7 +13111,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "TA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13160,7 +13163,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "TN" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -13292,7 +13295,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Uh" = (
 /obj/structure/window/reinforced{
 	health = 1e+007
@@ -13415,7 +13418,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "UH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13525,7 +13528,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Vh" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/random_multi/single_item/runtime,
@@ -13567,7 +13570,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Vl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -13580,7 +13583,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Vs" = (
 /obj/effect/floor_decal/corner/darkblue/mono,
 /obj/machinery/status_display{
@@ -13633,14 +13636,14 @@
 /obj/effect/floor_decal/corner/red/half,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "VP" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "VW" = (
 /obj/structure/rack,
 /obj/item/storage/box/PDAs{
@@ -13821,7 +13824,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "WL" = (
 /obj/effect/paint_stripe/engineering,
 /turf/simulated/wall/r_wall/prepainted,
@@ -13838,7 +13841,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "WV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13919,7 +13922,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Xh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/rack{
@@ -13965,7 +13968,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Xm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
@@ -14064,7 +14067,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Xz" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -14087,7 +14090,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "XC" = (
 /obj/effect/floor_decal/corner/darkblue/mono,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -14202,7 +14205,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Yj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -14212,7 +14215,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/bridge/fore)
+/area/hallway/bridge/fore)
 "Yl" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Infirmary"
@@ -14343,7 +14346,7 @@
 	sort_type = "Chief Medical Officer"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "YV" = (
 /obj/machinery/recharger/wallcharger{
 	dir = 4;
@@ -14427,7 +14430,7 @@
 /area/command/captainmess)
 "Zj" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/bridge/aft)
+/area/hallway/bridge/aft)
 "Zo" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -32256,12 +32259,12 @@ xi
 je
 it
 je
-Zj
+hS
 Kc
 Hg
 Nc
-fI
-Zj
+Ie
+hS
 ad
 ad
 ad
@@ -32458,12 +32461,12 @@ Zj
 Zj
 Zj
 Zj
-Zj
+hS
 Ky
 Mc
 Lg
-fI
-Zj
+Ie
+hS
 ad
 ad
 ad
@@ -32660,12 +32663,12 @@ ad
 ad
 ad
 ad
-Zj
-Zj
+hS
+hS
 Jg
-Zj
-Zj
-Zj
+hS
+hS
+hS
 ad
 ad
 ad
@@ -32863,9 +32866,9 @@ ad
 ad
 SA
 Ww
-Zj
+hS
 NM
-Zj
+hS
 Ww
 Ww
 Ww
@@ -33065,9 +33068,9 @@ iv
 iv
 jh
 ke
-Zj
+hS
 lX
-Zj
+hS
 Yb
 Yb
 Yb

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -5,6 +5,10 @@
 
 /area/hallway
 	area_flags = AREA_FLAG_HALLWAY
+	secure = TRUE
+
+/area/crew_quarters
+	secure = TRUE
 
 //Ported areas that do not exist in Nebula Base.
 /area/rnd/xenobiology/xenoflora
@@ -22,11 +26,11 @@
 	req_access = list(access_brig)
 
 //Fifth Deck (Z-0)
-/area/hallway/primary/fifthdeck/fore
+/area/hallway/fifthdeck/fore
 	name = "\improper Fifth Deck Fore Hallway"
 	icon_state = "hallF"
 
-/area/hallway/primary/fifthdeck/aft
+/area/hallway/fifthdeck/aft
 	name = "\improper Fifth Deck Aft Hallway"
 	icon_state = "hallA"
 
@@ -50,15 +54,15 @@
 	name = "Fifth Deck Substation"
 
 //Fourth Deck (Z-1)
-/area/hallway/primary/fourthdeck/fore
+/area/hallway/fourthdeck/fore
 	name = "\improper Fourth Deck Fore Hallway"
 	icon_state = "hallF"
 
-/area/hallway/primary/fourthdeck/center
+/area/hallway/fourthdeck/center
 	name = "\improper Fourth Deck Central Hallway"
 	icon_state = "hallC3"
 
-/area/hallway/primary/fourthdeck/aft
+/area/hallway/fourthdeck/aft
 	name = "\improper Fourth Deck Aft Hallway"
 	icon_state = "hallA"
 
@@ -94,15 +98,15 @@
 	name = "Fourth Deck Substation"
 
 //Third Deck (Z-2)
-/area/hallway/primary/thirddeck/fore
+/area/hallway/thirddeck/fore
 	name = "\improper Third Deck Fore Hallway"
 	icon_state = "hallF"
 
-/area/hallway/primary/thirddeck/center
+/area/hallway/thirddeck/center
 	name = "\improper Third Deck Central Hallway"
 	icon_state = "hallC3"
 
-/area/hallway/primary/thirddeck/aft
+/area/hallway/thirddeck/aft
 	name = "\improper Third Deck Aft Hallway"
 	icon_state = "hallA"
 
@@ -176,18 +180,18 @@
 	name = "Second Deck Central Maintenance"
 	icon_state = "maintcentral"
 
-/area/hallway/primary/seconddeck
+/area/hallway/seconddeck
 	name = "Second Deck Central Hallway"
 	icon_state = "hallC2"
 
-/area/hallway/primary/seconddeck/center
+/area/hallway/seconddeck/center
 	name = "\improper Second Deck Stairwell"
 
-/area/hallway/primary/seconddeck/elevator
+/area/hallway/seconddeck/elevator
 	name = "Second Deck Elevator Landing"
 	icon_state = "hallC2_e"
 
-/area/hallway/primary/seconddeck/fore
+/area/hallway/seconddeck/fore
 	name = "Second Deck Fore Hallway"
 	icon_state = "hallF2"
 
@@ -231,15 +235,15 @@
 	name = "\improper First Deck Teleporter"
 	icon_state = "teleporter"
 
-/area/hallway/primary/firstdeck/fore
+/area/hallway/firstdeck/fore
 	name = "\improper First Deck Fore Hallway"
 	icon_state = "hallF"
 
-/area/hallway/primary/firstdeck/center
+/area/hallway/firstdeck/center
 	name = "\improper First Deck Central Hallway"
 	icon_state = "hallC1"
 
-/area/hallway/primary/firstdeck/aft
+/area/hallway/firstdeck/aft
 	name = "\improper First Deck Aft Hallway"
 	icon_state = "hallA"
 
@@ -267,11 +271,11 @@
 	name = "Bridge Fore Port Maintenance"
 	icon_state = "fpmaint"
 
-/area/hallway/primary/bridge/fore
+/area/hallway/bridge/fore
 	name = "\improper Bridge Fore Hallway"
 	icon_state = "hallF"
 
-/area/hallway/primary/bridge/aft
+/area/hallway/bridge/aft
 	name = "\improper Bridge Aft Hallway"
 	icon_state = "hallA"
 
@@ -380,6 +384,7 @@
 	requires_power = 1
 	dynamic_lighting = 1
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	secure = TRUE
 
 /area/perseverance/cockpit
 	name = "\improper ISEO Perseverance - Cockpit"
@@ -553,6 +558,9 @@
 
 // Command
 
+/area/command
+	secure = TRUE
+
 /area/command/captainmess
 	name = "Officer's Mess"
 	icon_state = "bar"
@@ -629,6 +637,9 @@
 
 // Engineering
 
+/area/engineering
+	secure = TRUE
+
 /area/engineering/shieldbay
 	name = "Shield Bay"
 	icon_state = "engineering"
@@ -671,6 +682,7 @@
 /area/vacant
 	name = "\improper Vacant Area"
 	icon_state = "construction"
+	secure = TRUE
 
 /area/vacant/armory
 	name = "\improper Vacant Armory"
@@ -720,6 +732,9 @@
 	icon_state = "bar"
 
 // Storage
+/area/storage
+	secure = TRUE
+
 /area/storage/auxillary
 	req_access = list(access_cargo)
 
@@ -759,6 +774,7 @@
 
 /area/quartermaster
 	req_access = list(access_cargo)
+	secure = TRUE
 
 /area/quartermaster/office
 	name = "\improper Supply Office"
@@ -964,6 +980,7 @@
 
 /area/security
 	req_access = list(access_security)
+	secure = TRUE
 
 /area/security/processing
 	name = "Security - Processing Room"
@@ -1032,6 +1049,9 @@
 
 // Medbay
 
+/area/medical
+	secure = TRUE
+
 /area/medical/equipstorage
 	name = "\improper Medical Equipment Storage"
 	icon_state = "medbay4"
@@ -1045,7 +1065,7 @@
 /area/medical/foyer
 	name = "\improper Medical Foyer"
 	icon_state = "medbay"
-	req_access = list(list(access_medical,access_morgue,access_forensics_lockers))
+	req_access = list(access_medical,access_morgue,access_forensics_lockers)
 
 /area/medical/foyer/storeroom
 	name = "\improper Medical Storeroom"
@@ -1129,11 +1149,13 @@
 	icon_state = "teleporter"
 	sound_env = SMALL_ENCLOSED
 	req_access = list(access_teleporter)
+	secure = TRUE
 
 /area/eva
 	name = "\improper EVA Storage"
 	icon_state = "eva"
 	req_access = list(access_eva)
+	secure = TRUE
 
 /area/aux_eva
 	name = "\improper Command EVA Storage"
@@ -1143,6 +1165,7 @@
 /area/thruster
 	icon_state = "thruster"
 	req_access = list(access_engine)
+	secure = TRUE
 
 /area/thruster/d1port
 	name = "\improper First Deck Port Nacelle"
@@ -1177,6 +1200,7 @@
 	name = "\improper ISEO Endeavour Bridge"
 	icon_state = "bridge"
 	req_access = list(access_bridge)
+	secure = TRUE
 
 /area/bridge/hallway
 	name = "\improper Bridge Access Hallway"
@@ -1439,7 +1463,7 @@
 // Research
 /area/assembly
 	req_access = list(access_robotics)
-
+	secure = TRUE
 /area/assembly/chargebay
 	name = "\improper Mech Bay"
 	icon_state = "mechbay"
@@ -1460,6 +1484,7 @@
 
 /area/rnd
 	req_access = list(access_research)
+	secure = TRUE
 
 /area/rnd/misc_lab
 	name = "\improper Miscellaneous Research"
@@ -1526,6 +1551,7 @@
 	name = "\improper Custodial Closet"
 	icon_state = "janitor"
 	req_access = list(access_janitor)
+	secure = TRUE
 
 /area/janitor/storage
 	name = "\improper Custodial Storage Closet"
@@ -1550,9 +1576,10 @@
 	name = "\improper Cabin Four"
 
 // Tcomm
-/area/tcommsat/
+/area/tcommsat
 	ambience = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg')
 	req_access = list(access_tcomsat)
+	secure = TRUE
 
 /area/tcommsat/chamber
 	name = "\improper Telecoms Central Compartment"
@@ -1563,6 +1590,8 @@
 	icon_state = "tcomsatcomp"
 
 // Chapel
+/area/chapel
+	secure = TRUE
 
 /area/chapel/main
 	name = "\improper Chapel"

--- a/maps/torch/torch_unit_testing.dm
+++ b/maps/torch/torch_unit_testing.dm
@@ -9,7 +9,7 @@
 		/area/engineering/engine_smes = NO_SCRUBBER|NO_VENT,
 		/area/engineering/fuelbay = NO_SCRUBBER|NO_VENT,
 		/area/engineering/wastetank = NO_SCRUBBER|NO_VENT,
-		/area/hallway/primary/seconddeck/center = NO_SCRUBBER|NO_VENT,
+		/area/hallway/seconddeck/center = NO_SCRUBBER|NO_VENT,
 		/area/holodeck = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/maintenance = NO_SCRUBBER|NO_VENT,
 		/area/endeavour_exterior = NO_SCRUBBER|NO_VENT|NO_APC,

--- a/nebula.dme
+++ b/nebula.dme
@@ -1379,7 +1379,7 @@
 #include "code\modules\admin\buildmode\room_builder.dm"
 #include "code\modules\admin\buildmode\throw_at.dm"
 #include "code\modules\admin\callproc\callproc.dm"
-#include "code\modules\admin\DB ban\functions.dm"
+#include "code\modules\admin\Dbban\functions.dm"
 #include "code\modules\admin\permissionverbs\permissionedit.dm"
 #include "code\modules\admin\secrets\admin_secrets\admin_logs.dm"
 #include "code\modules\admin\secrets\admin_secrets\bombing_list.dm"


### PR DESCRIPTION
:cl:
bugfix: 
Частично решена проблема белого космоса(После появления он обратно исчезает, но потом надо доработать)

Уменьшена мощность лампочек
обычная с 8 до 6 дистанция
усиленная с 12 до 8 дистанция, с 4 до 1 сила

Теперь на Low wall нельзя забраться, если там стоит окно

Доступ к эмиттеру в Anomaly Lab имеют только учёные
Сканер аномалий теперь физический и прикручен к полу

tweak:
Портирование бан панели

Исправлено разрешение окна сканера здоровья, теперь оно открывается сразу оптимального размера

mapping:
Добавил на все зоны флаг secure, теперь доступы на шлюзы раздаются корректно

Поправил отображение спрайта криокамеры
В ЕВА и раздевалку исследователей добавлены диспенсеры баллонов

Переименована одна area, для удобства

/:cl:
