### PR TITLE
Hijack pods

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -1685,13 +1685,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
-	dir = 4;
-	id_tag = "escape_pod_18";
-	name = "escape pod thirteen controller";
-	pixel_x = -32;
-	tag_door = "escape_pod_18_hatch"
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/escape_pod18/station)
 "ed" = (
@@ -9074,6 +9067,13 @@
 /obj/item/radio/intercom{
 	pixel_y = 23
 	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
+	dir = 8;
+	id_tag = "escape_pod_18";
+	name = "escape pod thirteen controller";
+	pixel_x = 23;
+	tag_door = "escape_pod_18_hatch"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod18/station)
 "za" = (
@@ -9278,7 +9278,7 @@
 /area/exploration_shuttle/cargo)
 "AM" = (
 /obj/machinery/door/airlock/external/escapepod{
-	id_tag = "escape_pod_10_berth_hatch";
+	id_tag = "escape_pod_19_berth_hatch";
 	name = "Escape Pod Five"
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
@@ -9424,7 +9424,9 @@
 /area/shuttle/escape_pod18/station)
 "BV" = (
 /obj/machinery/door/blast/regular/escape_pod{
-	dir = 4
+	dir = 4;
+	id_tag = "escape_pod_19";
+	name = "Escape Pod release Door 19"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fifthdeck/aftport)
@@ -11715,13 +11717,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
-	dir = 4;
-	id_tag = "escape_pod_19";
-	name = "escape pod fourteen controller";
-	pixel_x = -32;
-	tag_door = "escape_pod_19_hatch"
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/escape_pod19/station)
 "Rj" = (
@@ -12131,7 +12126,9 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "Un" = (
 /obj/machinery/door/blast/regular/escape_pod{
-	dir = 4
+	dir = 4;
+	id_tag = "escape_pod_18";
+	name = "Escape Pod release Door 18"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fifthdeck/aftstarboard)
@@ -12896,6 +12893,13 @@
 	},
 /obj/item/radio/intercom{
 	pixel_y = 23
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
+	dir = 8;
+	id_tag = "escape_pod_19";
+	name = "escape pod fourteen controller";
+	pixel_x = 23;
+	tag_door = "escape_pod_19_hatch"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod19/station)

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -2770,7 +2770,7 @@
 	},
 /obj/structure/sign/warning/pods/south,
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/maintenance/fifthdeck/aftstarboard)
 "hk" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mining/brace{
@@ -3296,7 +3296,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/hangar)
+/area/hallway/primary/fifthdeck/aft)
 "iT" = (
 /obj/machinery/door/airlock/glass/science{
 	name = "Exploration Equipment"
@@ -4435,7 +4435,7 @@
 /obj/structure/closet/emcloset/torch,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
-/area/quartermaster/hangar)
+/area/hallway/primary/fifthdeck/aft)
 "lw" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -4444,7 +4444,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/quartermaster/hangar)
+/area/hallway/primary/fifthdeck/aft)
 "lx" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/anomaly_container,
@@ -5814,7 +5814,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fifthdeck/aft)
+/area/maintenance/fifthdeck/aftstarboard)
 "oE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -5825,7 +5825,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
-/area/hallway/primary/fifthdeck/aft)
+/area/maintenance/fifthdeck/aftport)
 "oF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6674,7 +6674,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/maintenance/fifthdeck/aftport)
 "qF" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -7588,7 +7588,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/maintenance/fifthdeck/aftport)
 "sI" = (
 /obj/abstract/landmark{
 	name = "xeno_spawn";
@@ -9086,7 +9086,7 @@
 "zb" = (
 /obj/machinery/cryopod{
 	dir = 1;
-	icon_state = "body_scanner_0"
+	icon_state = "open"
 	},
 /obj/machinery/computer/cryopod{
 	pixel_y = -32
@@ -9187,9 +9187,6 @@
 	icon_state = "walnut_broken0"
 	},
 /area/vacant/bar)
-"zS" = (
-/turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
 "zV" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -10024,9 +10021,6 @@
 /obj/machinery/atmospherics/valve/shutoff,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"Fk" = (
-/turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
 "Fn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -11758,7 +11752,7 @@
 "Rp" = (
 /obj/structure/sign/warning/pods,
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/maintenance/fifthdeck/aftport)
 "Rv" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -12553,7 +12547,7 @@
 "Xl" = (
 /obj/machinery/cryopod{
 	dir = 1;
-	icon_state = "body_scanner_0"
+	icon_state = "open"
 	},
 /obj/machinery/computer/cryopod{
 	pixel_y = -32
@@ -12627,7 +12621,7 @@
 	},
 /obj/structure/sign/warning/compressed_gas,
 /turf/simulated/wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/maintenance/fifthdeck/aftstarboard)
 "XI" = (
 /turf/simulated/wall/prepainted,
 /area/vacant/bar)
@@ -12886,7 +12880,7 @@
 	pixel_y = -4
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
-/area/hallway/primary/fifthdeck/aft)
+/area/maintenance/fifthdeck/aftport)
 "ZR" = (
 /obj/structure/bed/chair/armchair/beige{
 	dir = 4
@@ -35040,11 +35034,11 @@ WU
 qB
 Sc
 tQ
-zS
+ws
 qE
-zS
+ws
 sF
-zS
+ws
 HG
 MS
 MS
@@ -35242,7 +35236,7 @@ XE
 Sr
 Zo
 qF
-Fk
+gI
 ul
 wj
 wj
@@ -35844,11 +35838,11 @@ wH
 wH
 wH
 EL
-zS
+ZG
 HQ
 qC
 tF
-zS
+ws
 YL
 HS
 aC

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -274,9 +274,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod6/station)
 "bk" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -860,6 +857,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/sign/warning/docking_area{
+	name = "\improper ESCAPE POD LAUNCH PATHWAY";
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "dh" = (
@@ -880,6 +881,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
+"di" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/hallway/primary/fourthdeck/aft)
 "dj" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 4;
@@ -1072,6 +1084,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod7/station)
+"dT" = (
+/obj/machinery/door/blast/regular/escape_pod{
+	id_tag = "escape_pod_9";
+	name = "Escape Pod release Door"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/maintenance/fourthdeck/aft)
 "dU" = (
 /obj/structure/ladder,
 /obj/structure/catwalk,
@@ -1333,16 +1352,15 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Starboard Escape Pods";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/green/half{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8;
 	icon_state = "warningcorner"
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
@@ -1351,11 +1369,11 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/green/half{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "fa" = (
@@ -1596,7 +1614,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/structure/closet/hydrant{
+/obj/machinery/status_display{
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
@@ -1615,8 +1633,8 @@
 	dir = 8;
 	id_tag = "escape_pod_7_berth";
 	name = "escape pod two berth controller";
-	pixel_x = 24;
-	pixel_y = 24;
+	pixel_x = 25;
+	pixel_y = 30;
 	tag_door = "escape_pod_7_berth_hatch"
 	},
 /obj/structure/disposalpipe/segment,
@@ -1809,14 +1827,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "gM" = (
@@ -2242,7 +2259,10 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/obj/machinery/door/blast/regular/escape_pod,
+/obj/machinery/door/blast/regular/escape_pod{
+	id_tag = "escape_pod_6";
+	name = "Escape Pod release Door"
+	},
 /turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/starboard)
 "ig" = (
@@ -2531,9 +2551,6 @@
 /obj/machinery/oxygen_pump{
 	pixel_x = 32
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -2543,7 +2560,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "jX" = (
-/obj/machinery/door/blast/regular/escape_pod,
+/obj/machinery/door/blast/regular/escape_pod{
+	id_tag = "escape_pod_8";
+	name = "Escape Pod release Door"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fourthdeck/port)
 "ka" = (
@@ -2795,18 +2815,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eva)
-"la" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 8
-	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "lb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -4623,7 +4631,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
-/obj/structure/closet/hydrant{
+/obj/machinery/status_display{
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
@@ -5500,11 +5508,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
 "uj" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 8
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck - Starboard Escape Pods";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
@@ -6067,7 +6073,10 @@
 /area/maintenance/fourthdeck/starboard)
 "wc" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/door/blast/regular/escape_pod,
+/obj/machinery/door/blast/regular/escape_pod{
+	id_tag = "escape_pod_9";
+	name = "Escape Pod release Door"
+	},
 /turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/aft)
 "wd" = (
@@ -6121,7 +6130,10 @@
 /turf/simulated/wall/map_preset/tan,
 /area/maintenance/fourthdeck/aft)
 "wp" = (
-/obj/machinery/door/blast/regular/escape_pod,
+/obj/machinery/door/blast/regular/escape_pod{
+	id_tag = "escape_pod_7";
+	name = "Escape Pod release Door"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fourthdeck/aft)
 "wq" = (
@@ -6331,7 +6343,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "wW" = (
-/obj/machinery/door/blast/regular/escape_pod,
+/obj/machinery/door/blast/regular/escape_pod{
+	id_tag = "escape_pod_6";
+	name = "Escape Pod release Door"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/fourthdeck/starboard)
 "wX" = (
@@ -6380,10 +6395,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 21
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
@@ -7408,7 +7419,10 @@
 /area/maintenance/fourthdeck/aft)
 "By" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/door/blast/regular/escape_pod,
+/obj/machinery/door/blast/regular/escape_pod{
+	id_tag = "escape_pod_8";
+	name = "Escape Pod release Door"
+	},
 /turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/port)
 "BD" = (
@@ -8314,9 +8328,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -8510,30 +8521,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage/upper)
-"FP" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 8
-	},
-/obj/structure/closet/walllocker/skinsuit{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "FS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 21
-	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "FV" = (
@@ -8718,8 +8716,8 @@
 	does_spin = null;
 	id_tag = "escape_pod_9_berth";
 	name = "escape pod four berth controller";
-	pixel_x = 24;
-	pixel_y = -24;
+	pixel_x = 25;
+	pixel_y = -30;
 	tag_door = "escape_pod_9_berth_hatch"
 	},
 /obj/structure/disposalpipe/segment,
@@ -8882,13 +8880,12 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "Hm" = (
@@ -9069,8 +9066,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment,
-/obj/structure/closet/walllocker/skinsuit{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
@@ -9330,9 +9328,6 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
 "IC" = (
@@ -9451,7 +9446,10 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/obj/machinery/door/blast/regular/escape_pod,
+/obj/machinery/door/blast/regular/escape_pod{
+	id_tag = "escape_pod_7";
+	name = "Escape Pod release Door"
+	},
 /turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/aft)
 "Jn" = (
@@ -9498,28 +9496,8 @@
 "Jt" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/hallway/primary/fourthdeck/aft)
-"Jx" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 8
-	},
-/obj/structure/sign/warning/docking_area{
-	name = "\improper ESCAPE POD LAUNCH PATHWAY";
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/fourthdeck/aft)
 "Jy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/docking_area{
 	name = "\improper ESCAPE POD LAUNCH PATHWAY";
@@ -9616,9 +9594,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fourthdeck/aft)
 "JP" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -9984,6 +9959,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "KW" = (
@@ -10284,9 +10260,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -10496,12 +10469,6 @@
 /area/maintenance/fourthdeck/aft)
 "Mx" = (
 /obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white{
 	dir = 8
 	},
 /obj/structure/sign/warning/docking_area{
@@ -10935,7 +10902,7 @@
 	dir = 1;
 	id_tag = "escape_pod_8";
 	name = "escape pod three controller";
-	pixel_y = -32;
+	pixel_y = -25;
 	tag_door = "escape_pod_8_hatch"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -10998,15 +10965,14 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Oa" = (
-/obj/structure/catwalk,
-/obj/structure/sign/warning/docking_area{
-	name = "\improper ESCAPE POD LAUNCH PATHWAY";
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/catwalk_plated/dark,
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet/hydrant{
+	pixel_x = 32
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/fourthdeck/port)
+/area/hallway/primary/fourthdeck/aft)
 "Ob" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -11224,8 +11190,13 @@
 /turf/simulated/open,
 /area/maintenance/fourthdeck/foreport)
 "OT" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall/map_preset/tan,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
 "OU" = (
 /obj/structure/sign/directions/engineering{
@@ -12409,7 +12380,7 @@
 	dir = 1;
 	id_tag = "escape_pod_9";
 	name = "escape pod four controller";
-	pixel_y = -32;
+	pixel_y = -25;
 	tag_door = "escape_pod_9_hatch"
 	},
 /obj/item/radio/intercom{
@@ -12846,7 +12817,7 @@
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
 	id_tag = "escape_pod_6";
 	name = "escape pod one controller";
-	pixel_y = 32;
+	pixel_y = 25;
 	tag_door = "escape_pod_6_hatch"
 	},
 /obj/item/radio/intercom{
@@ -13016,8 +12987,8 @@
 	dir = 4;
 	id_tag = "escape_pod_8_berth";
 	name = "escape pod three berth controller";
-	pixel_x = -24;
-	pixel_y = -24;
+	pixel_x = -25;
+	pixel_y = -30;
 	tag_door = "escape_pod_8_berth_hatch"
 	},
 /obj/effect/floor_decal/corner/green{
@@ -13313,8 +13284,8 @@
 	dir = 4;
 	id_tag = "escape_pod_6_berth";
 	name = "escape pod one berth controller";
-	pixel_x = -24;
-	pixel_y = 24;
+	pixel_x = -25;
+	pixel_y = 30;
 	tag_door = "escape_pod_6_berth_hatch"
 	},
 /obj/effect/floor_decal/corner/green{
@@ -14433,10 +14404,26 @@
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/map_preset/tan,
 /area/quartermaster/storage/upper)
+"Yg" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	alarm_id = "curiosity1";
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/fourthdeck/aft)
 "Yj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wallframe_spawn/reinforced/hull,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
 "Yk" = (
 /turf/simulated/floor/tiled/monotile,
@@ -14663,12 +14650,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "YR" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
 "YS" = (
@@ -14866,12 +14847,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
 "Zn" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 8
-	},
 /obj/structure/closet/walllocker/skinsuit{
 	dir = 4
 	},
@@ -15058,7 +15033,7 @@
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
 	id_tag = "escape_pod_7";
 	name = "escape pod two controller";
-	pixel_y = 32;
+	pixel_y = 25;
 	tag_door = "escape_pod_7_hatch"
 	},
 /obj/item/radio/intercom{
@@ -37943,7 +37918,7 @@ Ds
 Of
 Of
 iO
-Oa
+GW
 GT
 Kl
 Gt
@@ -39120,13 +39095,13 @@ UH
 LA
 LA
 LA
-NW
-NW
+LA
+LA
 LA
 Yw
 LA
-NW
-NW
+LA
+LA
 LA
 LA
 Xn
@@ -39144,13 +39119,13 @@ Xn
 Xn
 LA
 LA
-NW
-NW
+LA
+LA
 LA
 ZA
 LA
-NW
-NW
+LA
+LA
 LA
 LA
 LA
@@ -39320,17 +39295,17 @@ RR
 aJ
 bk
 Mx
-la
-FP
+Zn
+Zn
 YR
-YR
+uj
 eX
 US
 LU
-ag
+OT
 ag
 ZP
-ag
+Yj
 kD
 mQ
 ag
@@ -39344,18 +39319,18 @@ JA
 mD
 Ae
 Ve
-ag
+Yg
 Dw
 ag
-ag
+OT
 Fk
 Ud
 KU
 uj
-uj
+YR
 Zn
 Zn
-Jx
+Mx
 JP
 aJ
 Px
@@ -39524,7 +39499,7 @@ UR
 bJ
 sd
 HT
-Xc
+Oa
 Xc
 eY
 fP
@@ -39532,7 +39507,7 @@ gL
 Ya
 Ya
 jE
-Ya
+di
 Zc
 zp
 ZU
@@ -39546,15 +39521,15 @@ xr
 bd
 YI
 Nk
-Ya
+di
 Wl
 Ya
 Ya
 FS
 Gu
 Hg
-Xc
-Xc
+HT
+Oa
 IB
 fK
 Jy
@@ -39726,13 +39701,13 @@ bm
 LA
 LA
 LA
-NW
-NW
+LA
+LA
 LA
 dd
 LA
-NW
-NW
+LA
+LA
 LA
 LA
 Xn
@@ -39748,15 +39723,15 @@ QW
 Xn
 Hd
 Bo
-OT
 LA
-Yj
-Yj
+LA
+LA
+LA
 LA
 Gv
 LA
-NW
-NW
+LA
+LA
 LA
 LA
 LA
@@ -39964,7 +39939,7 @@ DX
 wc
 JS
 Ki
-wp
+dT
 pp
 Gt
 Gt
@@ -40166,7 +40141,7 @@ DX
 wc
 JS
 PV
-wp
+dT
 pp
 Gt
 Gt
@@ -40368,7 +40343,7 @@ JX
 wc
 JS
 MM
-wp
+dT
 pp
 Gt
 Gt
@@ -40570,7 +40545,7 @@ DX
 wc
 JS
 OB
-wp
+dT
 pp
 Gt
 Gt
@@ -40772,7 +40747,7 @@ DX
 wc
 JS
 OB
-wp
+dT
 pp
 Gt
 Gt

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -23,7 +23,7 @@
 	dir = 4;
 	id_tag = "escape_pod_11";
 	name = "escape pod six controller";
-	pixel_x = -32;
+	pixel_x = -25;
 	tag_door = "escape_pod_11_hatch"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -5848,7 +5848,7 @@
 	dir = 4;
 	id_tag = "escape_pod_10";
 	name = "escape pod five controller";
-	pixel_x = -32;
+	pixel_x = -25;
 	tag_door = "escape_pod_10_hatch"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -14647,7 +14647,9 @@
 /area/engineering/engine_room)
 "MQ" = (
 /obj/machinery/door/blast/regular/escape_pod{
-	dir = 4
+	dir = 4;
+	id_tag = "escape_pod_10";
+	name = "Escape Pod release Door 10"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/seconddeck/foreport)
@@ -15759,7 +15761,9 @@
 /area/maintenance/seconddeck/forestarboard)
 "PP" = (
 /obj/machinery/door/blast/regular/escape_pod{
-	dir = 4
+	dir = 4;
+	id_tag = "escape_pod_11";
+	name = "Escape Pod release Door 11"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/seconddeck/forestarboard)

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -3909,6 +3909,9 @@
 /obj/machinery/computer/cryopod{
 	pixel_x = -32
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod12/station)
 "ake" = (
@@ -4484,6 +4487,9 @@
 	},
 /obj/machinery/computer/cryopod{
 	pixel_x = -32
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod13/station)
@@ -11146,9 +11152,6 @@
 	dir = 1;
 	icon_state = "shuttle_chair_preview"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod12/station)
 "bNL" = (
@@ -11162,9 +11165,6 @@
 /obj/structure/bed/chair/shuttle{
 	dir = 1;
 	icon_state = "shuttle_chair_preview"
-	},
-/obj/machinery/light/small{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod13/station)
@@ -11288,9 +11288,6 @@
 	dir = 4;
 	pixel_x = -21
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
 	dir = 8;
 	id_tag = "escape_pod_15";
@@ -11305,9 +11302,6 @@
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = -21
-	},
-/obj/machinery/light/small{
-	dir = 4
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
 	dir = 8;
@@ -11346,9 +11340,6 @@
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = -21
-	},
-/obj/machinery/light/small{
-	dir = 4
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
 	dir = 8;
@@ -11425,11 +11416,17 @@
 	dir = 1;
 	icon_state = "open"
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod15/station)
 "cab" = (
 /obj/machinery/cryopod{
 	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod16/station)
@@ -11442,6 +11439,9 @@
 /obj/machinery/cryopod{
 	dir = 1;
 	icon_state = "open"
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod17/station)

--- a/mods/content/ss220_content/_ss220_content.dme
+++ b/mods/content/ss220_content/_ss220_content.dme
@@ -1,9 +1,16 @@
 #ifndef MODPACK_SS220_CONTENT
 #define MODPACK_SS220_CONTENT
+// Fix start
 #include "../../../code/modules/power/lighting.dm"
 #include "../../../code/modules/xenoarcheaology/machinery/artifact_analyser.dm"
 #include "fix_override.dm"
 #include "../../../code/controllers/subsystems/ticker.dm"
+// Fix end
+// Hijack pods start
+#include "../../../code/modules/shuttles/escape_pods.dm"
+#include "../../../code/game/machinery/embedded_controller/embedded_controller_base.dm"
+#include "hijack_pods.dm"
+// Hijack pods end
 #include "ss220_content.dm"
 #endif
 // BEGIN_INTERNALS

--- a/mods/content/ss220_content/_ss220_content.dme
+++ b/mods/content/ss220_content/_ss220_content.dme
@@ -3,6 +3,7 @@
 #include "../../../code/modules/power/lighting.dm"
 #include "../../../code/modules/xenoarcheaology/machinery/artifact_analyser.dm"
 #include "fix_override.dm"
+#include "../../../code/controllers/subsystems/ticker.dm"
 #include "ss220_content.dm"
 #endif
 // BEGIN_INTERNALS

--- a/mods/content/ss220_content/fix_override.dm
+++ b/mods/content/ss220_content/fix_override.dm
@@ -8,3 +8,7 @@
 /obj/machinery/artifact_analyser
 	anchored = 1
 	density = 1
+
+/datum/controller/subsystem/ticker/handle_tickets()
+	message_staff("<span class='warning'><b>Рестарт через [restart_timeout/10] секунд если администраторы не приостановят его.</b></span>")
+	end_game_state = END_GAME_ENDING

--- a/mods/content/ss220_content/hijack_pods.dm
+++ b/mods/content/ss220_content/hijack_pods.dm
@@ -1,5 +1,3 @@
-#define EVAC_CHAIR(varName) var/obj/structure/bed/chair/shuttle/##varName
-
 // Rewrited files start
 
 /datum/computer/file/embedded_program/docking/simple/escape_pod_berth
@@ -169,5 +167,3 @@
 			to_chat(user, "<font size='3'><span class='notice'>Ты не понимаешь что произошло с [src], но он выглядит не как обычно.</span></font>")
 
 // New files end
-
-#undef EVAC_CHAIR

--- a/mods/content/ss220_content/hijack_pods.dm
+++ b/mods/content/ss220_content/hijack_pods.dm
@@ -137,26 +137,27 @@
 	if(emagged)
 		if(isWrench(T) && user.skill_check(SKILL_ELECTRICAL, SKILL_ADEPT))     // позже нужно поменять на мультиметр, но для этого его нужно добавить в игру
 			to_chat(user, "<font size='3'><span class='notice'>Ты начал сбрасывать настройки [src], чтобы починить его.</span></font>")
-			if(do_after(user, 100, src))
-				emagged = FALSE
-				state("<font size='3'>Сброс до заводских настроек завершен!</font>")
-				sleep(5)
-				state("<font size='3'>Поиск центрального контроллера...</font>")
-				sleep(10)
-				state("<font size='3'>Найдено!")
-				sleep(10)
-				state("<font size='3'>Первичная настройка капсулы...</font>")
-				sleep(20)
-				state("<font size='3'>Успешно!</font>")
-				if (istype(program, /datum/computer/file/embedded_program/docking/simple/escape_pod_berth))
-					var/datum/computer/file/embedded_program/docking/simple/escape_pod_berth/arming_program = program
-					for(var/datum/shuttle/autodock/ferry/escape_pod/pod in escape_pods)
-						if(pod.arming_controller == arming_program)
-							pod.toggle_bds(TRUE)
-							break
-					if (arming_program.armed || arming_program.arming)
-						arming_program.unarm()
+			if(!do_after(user, 100, src))
 				return
+			emagged = FALSE
+			state("<font size='3'>Сброс до заводских настроек завершен!</font>")
+			sleep(5)
+			state("<font size='3'>Поиск центрального контроллера...</font>")
+			sleep(10)
+			state("<font size='3'>Найдено!")
+			sleep(10)
+			state("<font size='3'>Первичная настройка капсулы...</font>")
+			sleep(20)
+			state("<font size='3'>Успешно!</font>")
+			if (istype(program, /datum/computer/file/embedded_program/docking/simple/escape_pod_berth))
+				var/datum/computer/file/embedded_program/docking/simple/escape_pod_berth/arming_program = program
+				for(var/datum/shuttle/autodock/ferry/escape_pod/pod in escape_pods)
+					if(pod.arming_controller == arming_program)
+						pod.toggle_bds(TRUE)
+						break
+				if (arming_program.armed || arming_program.arming)
+					arming_program.unarm()
+
 		else
 			to_chat(user, "<font size='3'><span class='notice'>Ты не понимаешь что произошло с [src], но он выглядит не как обычно.</span></font>")
 

--- a/mods/content/ss220_content/hijack_pods.dm
+++ b/mods/content/ss220_content/hijack_pods.dm
@@ -6,10 +6,11 @@
 	var/arming = FALSE
 
 /datum/computer/file/embedded_program/docking/simple/escape_pod_berth/arm()
-	if(!armed)
-		armed = 1
-		arming = FALSE
-		toggleDoor(memory["door_status"], tag_door, TRUE, "open")
+	if(armed)
+		return
+	armed = 1
+	arming = FALSE
+	toggleDoor(memory["door_status"], tag_door, TRUE, "open")
 
 /datum/shuttle/autodock/ferry/escape_pod/can_force()
 	if (arming_controller && arming_controller.master.emagged)

--- a/mods/content/ss220_content/hijack_pods.dm
+++ b/mods/content/ss220_content/hijack_pods.dm
@@ -5,9 +5,6 @@
 /datum/computer/file/embedded_program/docking/simple/escape_pod_berth
 	var/arming = FALSE
 
-/datum/shuttle/autodock/ferry/escape_pod
-	var/need_people	= 0
-
 /datum/computer/file/embedded_program/docking/simple/escape_pod_berth/arm()
 	if(!armed)
 		armed = 1
@@ -136,25 +133,6 @@
 		signal_door("secure_close")
 	else if(memory["door_status"]["lock"] == "unlocked")
 		signal_door("lock")
-
-/datum/shuttle/autodock/ferry/escape_pod/proc/check_load()
-	var/list/counted = list()
-	var/i = 0
-	EVAC_CHAIR(temp)
-	for(temp in shuttle_area[1])
-		if(temp.buckled_mob)
-			counted += temp.buckled_mob
-			if(counted.len >= need_people)
-				return TRUE
-		i++
-	if(i < need_people)	// someone broke a chair
-		for(var/mob/living/M in shuttle_area[1])
-			if(M in counted)
-				continue
-			counted += M
-			if(counted.len >= need_people)
-				return TRUE
-	return FALSE
 
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth/attackby(var/obj/item/T, var/mob/living/carbon/human/user)
 	if(emagged)

--- a/mods/content/ss220_content/hijack_pods.dm
+++ b/mods/content/ss220_content/hijack_pods.dm
@@ -40,7 +40,7 @@
 			overlays += image(icon, "indicator_forced")
 		airlock_program = docking_program.airlock_program
 
-	if(istype(airlock_program) && airlock_program.memory["processing"])
+	else if(istype(airlock_program) && airlock_program.memory["processing"])
 		if(airlock_program.memory["pump_status"] == "siphon")
 			overlays += image(icon, "screen_drain")
 		else

--- a/mods/content/ss220_content/hijack_pods.dm
+++ b/mods/content/ss220_content/hijack_pods.dm
@@ -1,0 +1,188 @@
+#define EVAC_CHAIR(varName) var/obj/structure/bed/chair/shuttle/##varName
+
+// Rewrited files start
+
+/datum/computer/file/embedded_program/docking/simple/escape_pod_berth
+	var/arming = FALSE
+
+/datum/shuttle/autodock/ferry/escape_pod
+	var/need_people	= 0
+
+/datum/computer/file/embedded_program/docking/simple/escape_pod_berth/arm()
+	if(!armed)
+		armed = 1
+		arming = FALSE
+		toggleDoor(memory["door_status"], tag_door, TRUE, "open")
+
+/datum/shuttle/autodock/ferry/escape_pod/can_force()
+	if (arming_controller && arming_controller.master.emagged)
+		return (next_location && next_location.is_valid(src) && !current_location.cannot_depart(src) && moving_status == SHUTTLE_IDLE && !location && arming_controller && arming_controller.armed)
+	if (arming_controller.eject_time && world.time < arming_controller.eject_time + 50)
+		return 0	//dont allow force launching until 5 seconds after the arming controller has reached it's countdown
+	return ..()
+
+/obj/machinery/embedded_controller/radio/on_update_icon()
+	overlays.Cut()
+	if(!on || !istype(program))
+		return
+	if(emagged)
+		overlays += image(icon, "screen_drain")
+		overlays += image(icon, "indicator_active")
+		overlays += image(icon, "indicator_forced")
+		overlays += image(icon, "indicator_done")
+		return
+	if(!program.memory["processing"])
+		overlays += image(icon, "screen_standby")
+		overlays += image(icon, "indicator_done")
+	else
+		overlays += image(icon, "indicator_active")
+	var/datum/computer/file/embedded_program/docking/airlock/docking_program = program
+	var/datum/computer/file/embedded_program/airlock/airlock_program = program
+	if(istype(docking_program))
+		if(docking_program.override_enabled)
+			overlays += image(icon, "indicator_forced")
+		airlock_program = docking_program.airlock_program
+
+	if(istype(airlock_program) && airlock_program.memory["processing"])
+		if(airlock_program.memory["pump_status"] == "siphon")
+			overlays += image(icon, "screen_drain")
+		else
+			overlays += image(icon, "screen_fill")
+
+/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+	var/data[0]
+	var/datum/computer/file/embedded_program/docking/simple/docking_program = program
+
+	data = list(
+		"docking_status" = docking_program.get_docking_status(),
+		"override_enabled" = docking_program.override_enabled,
+		"door_state" = 	docking_program.memory["door_status"]["state"],
+		"door_lock" = 	docking_program.memory["door_status"]["lock"],
+		"can_force" = pod.can_force() || (SSevac.evacuation_controller?.has_evacuated() && pod.can_launch()),	//allow players to manually launch ahead of time
+		"is_armed" = pod.arming_controller.armed,
+	)
+
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+
+	if (!ui)
+		ui = new(user, src, ui_key, "escape_pod_console.tmpl", name, 470, 290)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
+
+/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth/emag_act(var/remaining_charges, var/mob/user)
+	if (!emagged)
+		to_chat(user, "<font size='3'><span class='notice'>You emag the [src], arming the escape pod!</span></font>")
+		emagged = TRUE
+		get_global_announcer().autosay("<font size='4'><b>Несанкционированный доступ</b> к контроллеру эвакуации. Потеряно управление от <b><i>[src]</i></b>. Службе безопасности рекомендуется проследовать к этой капсуле. Местоположение капсулы: [get_area(src)]</font>", "Automatic Security System", "Security")
+		state("<font size='3'>Ошибка центрального контроллера!</font>")
+		sleep(5)
+		state("<font size='3'>Обнаружена аварийная ситуация!</font>")
+		sleep(3)
+		state("<font size='3'>Взведение капсулы...</font>")
+		sleep(10)
+		state("<font size='3'>Ошибка стыковочных зажимов!</font>")
+		sleep(5)
+		state("<font size='3'>Отключение зажимов...</font>")
+		sleep(20)
+		state("<font size='3'>Примерное время подготовки: 3 минуты.</font>")
+		if (istype(program, /datum/computer/file/embedded_program/docking/simple/escape_pod_berth))
+			var/datum/computer/file/embedded_program/docking/simple/escape_pod_berth/arming_program = program
+			if (!arming_program.armed)
+				arming_program.arming = TRUE
+				addtimer(CALLBACK(arming_program, /datum/computer/file/embedded_program/docking/simple/escape_pod_berth/proc/arm), 3 MINUTES)
+		return 1
+
+/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod/OnTopic(user, href_list)
+	if(href_list["command"] == "manual_arm")
+		if(pod.arming_controller.arming)
+			to_chat(user, "<font size='3'><span class='notice'>Ошибка! Подготовка капсулы уже производится, ожидайте.</span></font>")
+		else
+			pod.arming_controller.arm()
+		return TOPIC_REFRESH
+
+	if(href_list["command"] == "force_launch")
+		if (pod.can_force())
+			get_global_announcer().autosay("<font size='4'>Несанкционированный запуск капсулы <b>[pod]</b>! Возможна разгерметизация!</font>", "Evacuation Controller")
+			pod.force_launch(src)
+		else if (SSevac.evacuation_controller?.has_evacuated() && pod.can_launch())	//allow players to manually launch ahead of time if the shuttle leaves
+			pod.launch(src)
+		return TOPIC_REFRESH
+
+// Rewrited files end
+// New files start
+/datum/shuttle/autodock/ferry/escape_pod/proc/toggle_bds(var/CLOSE = FALSE)
+	for(var/obj/machinery/door/blast/regular/escape_pod/ES in world)
+		if(ES.id_tag == shuttle_docking_controller.id_tag)
+			if(CLOSE)
+				INVOKE_ASYNC(ES, /obj/machinery/door/blast/proc/force_close)
+			else
+				INVOKE_ASYNC(ES, /obj/machinery/door/blast/proc/force_open)
+
+/datum/computer/file/embedded_program/docking/simple/escape_pod_berth/proc/unarm()
+	if(armed)
+		armed = 0
+		arming = FALSE
+		toggleDoor(memory["door_status"], tag_door, TRUE, "close")
+
+/datum/computer/file/embedded_program/docking/simple/proc/signal_door(var/command)
+	var/datum/signal/signal = new
+	signal.data["tag"] = tag_door
+	signal.data["command"] = command
+	post_signal(signal)
+
+/datum/computer/file/embedded_program/docking/simple/proc/close_door()
+	if(memory["door_status"]["state"] == "open")
+		signal_door("secure_close")
+	else if(memory["door_status"]["lock"] == "unlocked")
+		signal_door("lock")
+
+/datum/shuttle/autodock/ferry/escape_pod/proc/check_load()
+	var/list/counted = list()
+	var/i = 0
+	EVAC_CHAIR(temp)
+	for(temp in shuttle_area[1])
+		if(temp.buckled_mob)
+			counted += temp.buckled_mob
+			if(counted.len >= need_people)
+				return TRUE
+		i++
+	if(i < need_people)	// someone broke a chair
+		for(var/mob/living/M in shuttle_area[1])
+			if(M in counted)
+				continue
+			counted += M
+			if(counted.len >= need_people)
+				return TRUE
+	return FALSE
+
+/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth/attackby(var/obj/item/T, var/mob/living/carbon/human/user)
+	if(emagged)
+		if(isWrench(T) && user.skill_check(SKILL_ELECTRICAL, SKILL_ADEPT))     // позже нужно поменять на мультиметр, но для этого его нужно добавить в игру
+			to_chat(user, "<font size='3'><span class='notice'>Ты начал сбрасывать настройки [src], чтобы починить его.</span></font>")
+			if(do_after(user, 100, src))
+				emagged = FALSE
+				state("<font size='3'>Сброс до заводских настроек завершен!</font>")
+				sleep(5)
+				state("<font size='3'>Поиск центрального контроллера...</font>")
+				sleep(10)
+				state("<font size='3'>Найдено!")
+				sleep(10)
+				state("<font size='3'>Первичная настройка капсулы...</font>")
+				sleep(20)
+				state("<font size='3'>Успешно!</font>")
+				if (istype(program, /datum/computer/file/embedded_program/docking/simple/escape_pod_berth))
+					var/datum/computer/file/embedded_program/docking/simple/escape_pod_berth/arming_program = program
+					for(var/datum/shuttle/autodock/ferry/escape_pod/pod in escape_pods)
+						if(pod.arming_controller == arming_program)
+							pod.toggle_bds(TRUE)
+							break
+					if (arming_program.armed || arming_program.arming)
+						arming_program.unarm()
+				return
+		else
+			to_chat(user, "<font size='3'><span class='notice'>Ты не понимаешь что произошло с [src], но он выглядит не как обычно.</span></font>")
+
+// New files end
+
+#undef EVAC_CHAIR

--- a/mods/content/ss220_content/hijack_pods.dm
+++ b/mods/content/ss220_content/hijack_pods.dm
@@ -47,10 +47,9 @@
 			overlays += image(icon, "screen_fill")
 
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	var/data[0]
 	var/datum/computer/file/embedded_program/docking/simple/docking_program = program
 
-	data = list(
+	var/list/data = list(
 		"docking_status" = docking_program.get_docking_status(),
 		"override_enabled" = docking_program.override_enabled,
 		"door_state" = 	docking_program.memory["door_status"]["state"],


### PR DESCRIPTION
# Описание

* Угон эвакуационных подов
* Рестарт в конце раунда, даже если есть тикеты
* Правка карты и зон

## Основные изменения

* Появилась возможность угонять эвакуационные поды, путём их взлома емагом
* Появилась возможность чинить эвакуационные поды, после их взлома емагом
* Расширена зона техов на 1 палубе
* Теперь активные тикеты не препятствуют рестарту сервера
* Маленькое изменение внешнего вида коридоров около подов на второй палубе

:cl:
bugfix: 
Теперь активные тикеты не препятствуют рестарту сервера.
Раньше это мешало рестартнуться серверу, даже если тикеты впоследствии были закрыты


tweak:
Добавлена возможность угонять поды с помощью емага, для этого вам необходимо взломать емагом контроллер пода, и подождать 3 минуты до того как под "подготовится", если вы вломитесь в под раньше этого срока, вам всё равно придётся дождаться окончания таймера.

Во время взлома, идёт оповещение в канал охраны, в котором говорится местоположение пода, который вы начали взламывать.
Так же оповещение в общий канал идёт, когда вы уже улетели, в нём предупреждают об опасности разгерметизации.

У инженеров с прокаченным навыком электроники, а именно начиная с уровня trained, есть возможность с помощью гаечного ключа починить взломанный под.

mapping:
Поправил зону технических тоннелей на 1 палубе
/:cl: