### PR TITLE
Head needed, send back to lobby, map and access fixes

### DIFF
--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -376,6 +376,18 @@ var/global/const/access_heads = "ACCESS_HEADS" //67
 	desc = "Command"
 	region = ACCESS_REGION_COMMAND
 
+var/global/const/access_engine_trainee_equip = "ACCESS_ENGINE_TRAINEE_EQUIP" //68
+/datum/access/engine_trainee_equip
+	id = access_engine_trainee_equip
+	desc = "Trainee's locker room"
+	region = ACCESS_REGION_ENGINEERING
+
+var/global/const/access_engine_normal_equip = "ACCESS_ENGINE_NORMAL_EQUIP" //69
+/datum/access/engine_normal_equip
+	id = access_engine_normal_equip
+	desc = "Normal's locker room"
+	region = ACCESS_REGION_ENGINEERING
+
 /******************
 * Central Command *
 ******************/

--- a/code/game/jobs/job/_job.dm
+++ b/code/game/jobs/job/_job.dm
@@ -1,5 +1,5 @@
 /datum/job
-	var/title                                 // The name of the job	
+	var/title                                 // The name of the job
 	var/list/software_on_spawn = list()       // Defines the software files that spawn on tablets and labtops
 	var/list/department_types = list()        // What departments the job is in.
 	var/autoset_department = TRUE             // If department list is empty, use map default.
@@ -35,6 +35,7 @@
 	var/latejoin_at_spawnpoints               // If this job should use roundstart spawnpoints for latejoin (offstation jobs etc)
 	var/forced_spawnpoint                     // If set to a spawnpoint name, will use that spawn point for joining as this job.
 	var/hud_icon						      // icon used for Sec HUD overlay
+	var/required_role = null			      //a role which necessery to join as the job. For an example, explorers cannot be without EL
 
 	//Job access. The use of minimal_access or access is determined by a config setting: config.jobs_have_minimal_access
 	var/list/minimal_access = list()          // Useful for servers which prefer to only have access given to the places a job absolutely needs (Larger server population)
@@ -227,6 +228,10 @@
 		to_chat(feedback, "<span class='boldannounce'>Not old enough. Minimum character age is [minimum_character_age[S.get_root_species_name()]].</span>")
 		return TRUE
 
+	if(!is_required_roles_filled())
+		to_chat(feedback, "<span class='boldannounce'>For joining as [title] there should be [jointext(required_role, ", ")] in crew.</span>")
+		return TRUE
+
 	if(!S.check_background(src, prefs))
 		to_chat(feedback, "<span class='boldannounce'>Incompatible background for [title].</span>")
 		return TRUE
@@ -378,6 +383,8 @@
 		reasons["You are semi-antagonist banned."] = TRUE
 	if(!player_old_enough(caller))
 		reasons["Your player age is too low."] = TRUE
+	if(!is_required_roles_filled())
+		reasons["There are no employees who can train you."] = TRUE
 	if(!is_position_available())
 		reasons["There are no positions left."] = TRUE
 	if(!isnull(allowed_branches) && (!caller.prefs.branches[title] || !is_branch_allowed(caller.prefs.branches[title])))
@@ -426,6 +433,20 @@
 		return pick(loc_list)
 	else
 		return locate("start*[title]") // use old stype
+
+/datum/job/proc/is_required_roles_filled()
+	if(!required_role) return 1
+
+	// Abstract submap jobs is not writing to SStrade.primary_job_datums
+	if(istype(src, /datum/job/submap))
+		for(var/mob/M in global.player_list)
+			if(M.client && M.mind && M.mind.assigned_job && (M.mind.assigned_job.title in required_role))
+				return 1
+
+	for(var/datum/job/J in SSjobs.primary_job_datums)
+		if(J.title in required_role)
+			if(J.current_positions || !J.total_positions)
+				return 1
 
 /**
  *  Return appropriate /decl/spawnpoint for given client

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -78,7 +78,8 @@ var/global/floorIsLava = 0
 		<A href='?_src_=holder;warn=[last_ckey]'>Warn</A> |
 		<A href='?src=\ref[src];newban=\ref[M];last_key=[last_ckey]'>Ban</A> |
 		<A href='?src=\ref[src];jobban_panel_target=\ref[M]'>Jobban</A> |
-		<A href='?src=\ref[src];notes=show;mob=\ref[M]'>Notes</A>
+		<A href='?src=\ref[src];notes=show;mob=\ref[M]'>Notes</A> |
+		<A href='?_src_=holder;sendbacktolobby=\ref[M]'>Send back to Lobby</A> |
 	"}
 
 	if(M.client)
@@ -317,7 +318,7 @@ var/global/floorIsLava = 0
 			if(I.author == usr.key || I.author == "Adminbot" || ishost(usr))
 				dat += "<A href='?src=\ref[src];remove_player_info=[key];remove_index=[i]'>Remove</A>"
 			dat += "<hr></li>"
-		if(update_file) 
+		if(update_file)
 			direct_output(info, infos)
 
 	dat += "</ul><br><A href='?src=\ref[src];add_player_info=[key]'>Add Comment</A><br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3,6 +3,30 @@
 /datum/admins/Topic(href, href_list)
 	..()
 
+	if(href_list["sendbacktolobby"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/mob/M = locate(href_list["sendbacktolobby"])
+
+		if(!isobserver(M))
+			to_chat(usr, "<span class='notice'>You can only send ghost players back to the Lobby.</span>")
+			return
+
+		if(!M.client)
+			to_chat(usr, "<span class='warning'>[M] doesn't seem to have an active client.</span>")
+			return
+
+		if(alert(usr, "Send [key_name(M)] back to Lobby?", "Message", "Yes", "No") != "Yes")
+			return
+
+		log_admin("[key_name(usr)] has sent [key_name(M)] back to the Lobby.")
+		message_admins("[key_name(usr)] has sent [key_name(M)] back to the Lobby.")
+
+		var/mob/new_player/NP = new()
+		NP.ckey = M.ckey
+		qdel(M)
+
 	if(usr.client != src.owner || !check_rights(0))
 		log_admin("[key_name(usr)] tried to use the admin panel without authorization.")
 		message_admins("[usr.key] has attempted to override the admin panel!")

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -165,6 +165,8 @@
 					bad_message = "<b>\[SPECIES RESTRICTED]</b>"
 				else if(!S.check_background(job, user.client.prefs))
 					bad_message = "<b>\[BACKGROUND RESTRICTED]</b>"
+				else if(!job.is_required_roles_filled())
+					bad_message = "\[HEAD NEEDED]"
 				else
 					var/special_block = job.check_special_blockers(user.client.prefs)
 					if(special_block)

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -107,7 +107,7 @@
 
 	allowed = list(/obj/item/flashlight,/obj/item/tank,/obj/item/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/inflatable_dispenser,/obj/item/t_scanner,/obj/item/rcd)
 
-	req_access = list(access_engine_equip)
+	req_access = list(access_engine_normal_equip)
 
 /obj/item/clothing/head/helmet/space/rig/eva
 	light_overlay = "helmet_light_dual"

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -32,7 +32,7 @@
 
 	access = list(
 		access_captain, access_security, access_brig, access_armory, access_forensics_lockers, access_heads, access_medical, access_morgue, access_tox, access_tox_storage,
-		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
+		access_engine, access_engine_equip, access_engine_normal_equip, access_engine_trainee_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
 		access_ai_upload, access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_chapel_office, access_tech_storage,
 		access_atmospherics, access_bar, access_janitor, access_crematorium, access_kitchen, access_robotics, access_cargo, access_construction,
 		access_chemistry, access_cargo_bot, access_hydroponics, access_manufacturing, access_library, access_lawyer, access_virology, access_cmo,
@@ -48,7 +48,7 @@
 
 	minimal_access = list(
 		access_captain, access_security, access_brig, access_armory, access_forensics_lockers, access_heads, access_medical, access_morgue, access_tox, access_tox_storage,
-		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
+		access_engine, access_engine_equip, access_engine_normal_equip, access_engine_trainee_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
 		access_ai_upload, access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_chapel_office, access_tech_storage,
 		access_atmospherics, access_bar, access_janitor, access_crematorium, access_kitchen, access_robotics, access_cargo, access_construction,
 		access_chemistry, access_cargo_bot, access_hydroponics, access_manufacturing, access_library, access_lawyer, access_virology, access_cmo,
@@ -104,7 +104,7 @@
 
 	access = list(
 		access_security, access_brig, access_armory, access_forensics_lockers, access_heads, access_medical, access_morgue, access_tox, access_tox_storage,
-		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
+		access_engine, access_engine_equip, access_engine_normal_equip, access_engine_trainee_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
 		access_ai_upload, access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_chapel_office, access_tech_storage,
 		access_atmospherics, access_bar, access_janitor, access_crematorium, access_kitchen, access_robotics, access_cargo, access_construction,
 		access_chemistry, access_cargo_bot, access_hydroponics, access_manufacturing, access_library, access_lawyer, access_virology, access_cmo,
@@ -120,7 +120,7 @@
 
 	minimal_access = list(
 		access_security, access_brig, access_armory, access_forensics_lockers, access_heads, access_medical, access_morgue, access_tox, access_tox_storage,
-		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
+		access_engine, access_engine_equip, access_engine_normal_equip, access_engine_trainee_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_change_ids,
 		access_ai_upload, access_teleporter, access_eva, access_bridge, access_all_personal_lockers, access_chapel_office, access_tech_storage,
 		access_atmospherics, access_bar, access_janitor, access_crematorium, access_kitchen, access_robotics, access_cargo, access_construction,
 		access_chemistry, access_cargo_bot, access_hydroponics, access_manufacturing, access_library, access_lawyer, access_virology, access_cmo,
@@ -293,7 +293,7 @@
 	skill_points = 30
 
 	access = list(
-		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_engine, access_engine_equip, access_engine_normal_equip, access_engine_trainee_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
 		access_tech_storage, access_robotics, access_atmospherics, access_janitor, access_construction,
 		access_network, access_ce, access_RC_announce, access_keycard_auth, access_tcomsat,
@@ -303,7 +303,7 @@
 
 
 	minimal_access = list(
-		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_engine, access_engine_equip, access_engine_normal_equip, access_engine_trainee_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_ai_upload, access_teleporter, access_eva, access_bridge, access_heads,
 		access_tech_storage, access_atmospherics, access_janitor, access_construction,
 		access_network, access_ce, access_RC_announce, access_keycard_auth, access_tcomsat,

--- a/maps/torch/job/corporate_jobs.dm
+++ b/maps/torch/job/corporate_jobs.dm
@@ -63,6 +63,9 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERT,
 	                    SKILL_WEAPONS     = SKILL_EXPERT,
 	                    SKILL_FORENSICS   = SKILL_EXPERT)
+
+	required_role = list("Workplace Liaison")
+
 	alt_titles = list(
 		"Union Enforcer",
 		"Loss Prevention Associate",

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -35,7 +35,7 @@
 	skill_points = 24
 
 	access = list(
-		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_engine, access_engine_normal_equip, access_engine_trainee_equip, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
 		access_tcomsat, access_solgov_crew, access_seneng, access_hangar, access_network, access_radio_eng
 	)
@@ -100,7 +100,7 @@
 	skill_points = 20
 
 	access = list(
-		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_engine, access_engine_normal_equip, access_engine_trainee_equip, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
 		access_solgov_crew, access_hangar, access_radio_eng
 	)
@@ -159,7 +159,7 @@
 	required_role = list("Chief Engineer", "Senior Engineer")
 
 	access = list(
-		access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
+		access_engine_equip, access_engine_trainee_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_eva, access_tech_storage, access_janitor, access_construction,
 		access_solgov_crew, access_hangar, access_radio_eng
 	)

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -156,6 +156,8 @@
 	                    SKILL_ATMOS        = SKILL_MAX,
 	                    SKILL_ENGINES      = SKILL_MAX)
 
+	required_role = list("Chief Engineer", "Senior Engineer")
+
 	access = list(
 		access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_eva, access_tech_storage, access_janitor, access_construction,

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -109,6 +109,8 @@
 	                    SKILL_COMBAT      = SKILL_EXPERT,
 	                    SKILL_WEAPONS     = SKILL_EXPERT)
 
+	required_role = list("Pathfinder", "Shuttle Pilot")
+
 	access = list(
 		access_explorer, access_maint_tunnels, access_eva, access_emergency_storage,
 		access_opportunity_helm, access_solgov_crew, access_expedition_shuttle, access_opportunity, access_hangar,

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -167,6 +167,8 @@
 	                    SKILL_ANATOMY     = SKILL_MAX,
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
 
+	required_role = list("Chief Medical Officer", "Physician")
+
 	access = list(
 		access_medical, access_morgue, access_maint_tunnels,
 		access_external_airlocks, access_emergency_storage,

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -118,7 +118,7 @@
 	                    SKILL_CHEMISTRY   = SKILL_MAX)
 
 	access = list(
-		access_medical, access_morgue, access_maint_tunnels,
+		access_medical, access_morgue, access_senmed, access_maint_tunnels,
 		access_external_airlocks, access_emergency_storage,
 		access_eva, access_surgery, access_medical_equip,
 		access_solgov_crew, access_hangar, access_radio_med
@@ -172,7 +172,7 @@
 	access = list(
 		access_medical, access_morgue, access_maint_tunnels,
 		access_external_airlocks, access_emergency_storage,
-		access_surgery, access_medical_equip, access_solgov_crew,
+		access_surgery, access_medical_equip, access_senmed, access_solgov_crew,
 		access_radio_med
 	)
 
@@ -208,7 +208,7 @@
 	access = list(
 		access_medical, access_maint_tunnels, access_emergency_storage,
 		access_medical_equip, access_solgov_crew, access_chemistry,
-	 	access_virology, access_morgue, access_crematorium, access_radio_med
+	 	access_virology, access_morgue, access_crematorium, access_senmed, access_radio_med
 	)
 
 	minimal_access = list()
@@ -252,7 +252,7 @@
 	)
 	access = list(
 		access_medical, access_psychiatrist,
-		access_solgov_crew, access_medical_equip, access_radio_med
+		access_solgov_crew, access_medical_equip, access_senmed, access_radio_med
 	)
 
 	minimal_access = list()

--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -120,6 +120,8 @@
 	                    SKILL_DEVICES     = SKILL_MAX,
 	                    SKILL_SCIENCE     = SKILL_MAX)
 
+	required_role = list("Chief Science Officer", "Senior Researcher")
+
 	access = list(
 		access_tox, access_tox_storage, access_research, access_curiosity,
 		access_mining_office, access_mining_station, access_xenobiology, access_opportunity_helm,

--- a/maps/torch/structures/closets/engineering.dm
+++ b/maps/torch/structures/closets/engineering.dm
@@ -70,7 +70,7 @@
 
 /obj/structure/closet/secure_closet/engineering_torch
 	name = "engineer's locker"
-	req_access = list(access_engine_equip)
+	req_access = list(access_engine_normal_equip)
 	closet_appearance = /decl/closet_appearance/secure_closet/torch/engineering
 
 /obj/structure/closet/secure_closet/engineering_torch/WillContain()

--- a/maps/torch/structures/closets/engineering.dm
+++ b/maps/torch/structures/closets/engineering.dm
@@ -93,6 +93,31 @@
 		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi))
 	)
 
+/obj/structure/closet/secure_closet/engineering_trainee_torch
+	name = "engineer trainee's locker"
+	req_access = list(access_engine_trainee_equip)
+	closet_appearance = /decl/closet_appearance/secure_closet/torch/engineering
+
+/obj/structure/closet/secure_closet/engineering_trainee_torch/WillContain()
+	return list(
+		/obj/item/clothing/under/hazard,
+		/obj/item/clothing/accessory/storage/vest,
+		/obj/item/storage/belt/utility/full,
+		/obj/item/radio/headset/headset_eng,
+		/obj/item/radio/headset/headset_eng/alt,
+		/obj/item/clothing/suit/storage/hazardvest,
+		/obj/item/clothing/mask/gas,
+		/obj/item/clothing/glasses/meson,
+		/obj/item/taperoll/engineering,
+		/obj/item/flashlight,
+		/obj/item/taperoll/atmos,
+		/obj/item/clothing/gloves/insulated,
+		/obj/item/knife/folding/swiss/engineer,
+		/obj/item/clothing/head/hardhat/damage_control,
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/industrial, /obj/item/storage/backpack/satchel/eng)),
+		new /datum/atom_creator/weighted(list(/obj/item/storage/backpack/dufflebag/eng, /obj/item/storage/backpack/messenger/engi))
+	)
+
 /obj/structure/closet/secure_closet/engineering_senior
 	name = "senior engineer's locker"
 	req_access = list(access_seneng)

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -5150,7 +5150,7 @@
 /area/engineering/engine_monitoring)
 "mE" = (
 /turf/simulated/floor/tiled,
-/area/engineering/engineering_monitoring)
+/area/engineering/engineering_bay)
 "mF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/techfloor{
@@ -11763,6 +11763,11 @@
 	},
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/engineering/atmos)
+"Er" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/engineering_trainee_torch,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/locker_room)
 "Es" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -13170,8 +13175,8 @@
 /area/vacant/prototype/control)
 "Ik" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/engineering_torch,
 /obj/machinery/light,
+/obj/structure/closet/secure_closet/engineering_trainee_torch,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/locker_room)
 "Il" = (
@@ -38080,7 +38085,7 @@ kH
 wK
 ly
 nz
-kH
+Er
 nv
 pv
 qE

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -639,7 +639,7 @@
 /area/engineering/shieldbay
 	name = "Shield Bay"
 	icon_state = "engineering"
-	req_access = list(access_engine, access_engine_equip)
+	req_access = list(access_engine_equip)
 
 /area/engineering/bluespace
 	name = "Superluminal Drive Containment"
@@ -1061,11 +1061,12 @@
 /area/medical/foyer
 	name = "\improper Medical Foyer"
 	icon_state = "medbay"
-	req_access = list(access_medical,access_morgue,access_forensics_lockers)
+	req_access = list(access_medical)
 
 /area/medical/foyer/storeroom
 	name = "\improper Medical Storeroom"
 	icon_state = "medbay"
+	req_access = list(access_morgue,access_forensics_lockers)
 
 /area/medical/locker
 	name = "\improper Medical Locker Room"
@@ -1438,12 +1439,12 @@
 /area/engineering/locker_room
 	name = "\improper Engineering Locker Room"
 	icon_state = "engineering_locker"
-	req_access = list(access_engine)
+	req_access = list(access_engine_equip)
 
 /area/engineering/engineering_bay
 	name = "\improper Engineering Bay"
 	icon_state = "engineering_locker"
-	req_access = list(access_engine)
+	req_access = list(access_engine_equip)
 
 /area/engineering/storage
 	name = "\improper Engineering Storage"

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -357,8 +357,8 @@
 	sort_order = 12
 
 /datum/mil_rank/espatier/o3
-	name = "Captain"
-	name_short = "CPT"
+	name = "Commandor"
+	name_short = "COM"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/officer/o3)
 	sort_order = 13
 


### PR DESCRIPTION
# Описание

* Добавлена кнопка "Вернуть в Лобби"
* Ограничение на вход стажёров и исследователей если отсутствует глава или его заместитель
* Фиксы

## Основные изменения

* Добавлена кнопка Send back to Lobby, может вернуть только призрака
* Ограничение на вход в раунд для стажёров отделов, если нет Главы отдела или его заместителя 
* Ограничение на вход в раунд для исследователей , если нет Pathfinder или пилота шатла
* Переработка доступов стажёра инженеров и медиков
* Добавлены личные ящики для стажёров в инженерном отделе
* Правки карты и доступов

:cl:
bugfix: 
https://github.com/ss220-space/NebulaHestia/issues/26
Поправлены доступы стажёров в инженерке
Поправлены доступы медиков

tweak:
Добавлена кнопка Send back to Lobby, может вернуть только призрака

Ограничение на вход в раунд для стажёров отделов, если нет Главы отдела или его заместителя 
Ограничение на вход в раунд для исследователей , если нет Pathfinder или пилота шатла

mapping:
Мелкие правки
Докинул ящики стажёров в инженерку
/:cl: