### PR TITLE
FIX: missing DNA on object's blood

### DIFF
--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -703,23 +703,26 @@ var/global/list/slot_flags_enumeration = list(
 		blood_overlay.color = COLOR_LUMINOL
 		update_icon()
 
-/obj/item/add_blood(mob/living/carbon/human/M, amount = 2, blood_data)
+/obj/item/add_blood(mob/living/carbon/human/human, amount = 2, blood_data)
 	if (!..())
-		return 0
+		return FALSE
 
 	if(istype(src, /obj/item/energy_blade))
-		return
+		return FALSE
 
-	if(!blood_data && istype(M))
-		blood_data = REAGENT_DATA(M.vessel, /decl/material/liquid/blood)
-		if(!LAZYACCESS(blood_DNA, M.dna.unique_enzymes))
-			LAZYSET(blood_DNA, M.dna.unique_enzymes, M.dna.b_type)
-			LAZYSET(blood_data, M.dna.unique_enzymes, REAGENT_DATA(M.vessel, M.species.blood_reagent))
-			var/datum/extension/forensic_evidence/forensics = get_or_create_extension(M, /datum/extension/forensic_evidence)
-			forensics.add_data(/datum/forensics/blood_dna, M.dna.unique_enzymes)
-			add_coating(/decl/material/liquid/blood, amount, blood_data)
-		return 1
-	return 1 //we applied blood to the item
+	if(blood_data || !istype(human))
+		return TRUE
+
+	blood_data = REAGENT_DATA(human.vessel, /decl/material/liquid/blood)
+
+	if(!LAZYACCESS(blood_DNA, human.dna.unique_enzymes))
+		LAZYSET(blood_DNA, human.dna.unique_enzymes, human.dna.b_type)
+		LAZYSET(blood_data, human.dna.unique_enzymes, REAGENT_DATA(human.vessel, human.species.blood_reagent))
+		var/datum/extension/forensic_evidence/forensics = get_or_create_extension(human, /datum/extension/forensic_evidence)
+		forensics.add_data(/datum/forensics/blood_dna, human.dna.unique_enzymes)
+		add_coating(/decl/material/liquid/blood, amount, blood_data)
+
+	return TRUE
 
 var/global/list/blood_overlay_cache = list()
 

--- a/code/game/objects/item.dm
+++ b/code/game/objects/item.dm
@@ -712,9 +712,13 @@ var/global/list/slot_flags_enumeration = list(
 
 	if(!blood_data && istype(M))
 		blood_data = REAGENT_DATA(M.vessel, /decl/material/liquid/blood)
-	var/datum/extension/forensic_evidence/forensics = get_or_create_extension(src, /datum/extension/forensic_evidence)
-	forensics.add_data(/datum/forensics/blood_dna, LAZYACCESS(blood_data, "blood_DNA"))
-	add_coating(/decl/material/liquid/blood, amount, blood_data)
+		if(!LAZYACCESS(blood_DNA, M.dna.unique_enzymes))
+			LAZYSET(blood_DNA, M.dna.unique_enzymes, M.dna.b_type)
+			LAZYSET(blood_data, M.dna.unique_enzymes, REAGENT_DATA(M.vessel, M.species.blood_reagent))
+			var/datum/extension/forensic_evidence/forensics = get_or_create_extension(M, /datum/extension/forensic_evidence)
+			forensics.add_data(/datum/forensics/blood_dna, M.dna.unique_enzymes)
+			add_coating(/decl/material/liquid/blood, amount, blood_data)
+		return 1
 	return 1 //we applied blood to the item
 
 var/global/list/blood_overlay_cache = list()


### PR DESCRIPTION
### **Description of changes**
_Кровь на предметах, которыми можно атаковать, отныне имеет ДНК, по которому детектив может работать._ 

### **Why and what will this PR improve**
_Ранее отсутствие возможности изучать кровь на предметах/одежде и ином переносимом ломало кор-механику: детективную работу. Это не позволяло детективу играть полноценно, что делало роль бесполезной, а работа СБ нивелировалась отсутствием полноценного функционала поиска нарушителей._

**Исправляет:**
fix #78 