### PR TITLE
Resets player view after exiting overmap interface

### DIFF
--- a/code/modules/admin/buildmode/areas.dm
+++ b/code/modules/admin/buildmode/areas.dm
@@ -73,7 +73,7 @@ Right Click       - List/Create Area
 	var/used_colors = 0
 	var/list/max_colors = length(distinct_colors)
 	var/list/vision_colors = list()
-	for (var/turf/T in range(get_effective_view(user.client), user))
+	for (var/turf/T in range(user?.client?.view || world.view, user))
 		var/image/I = new('icons/turf/overlays.dmi', T, "whiteOverlay")
 		var/ref = "\ref[T.loc]"
 		if (!vision_colors[ref])

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -171,7 +171,7 @@
 	next_sonar_ping += 10 SECONDS
 	var/heard_something = FALSE
 	to_chat(src, "<span class='notice'>You take a moment to listen in to your environment...</span>")
-	for(var/mob/living/L in range(get_effective_view(client), src))
+	for(var/mob/living/L in range(client?.view || world.view, src))
 		var/turf/T = get_turf(L)
 		if(!T || L == src || L.stat == DEAD || is_below_sound_pressure(T))
 			continue

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -25,7 +25,7 @@ var/global/datum/topic_state/default/default_topic_state = new
 		return
 
 	// robots can interact with things they can see within their view range
-	if((src_object in view(src)) && get_dist(src_object, src) <= get_effective_view(client))
+	if((src_object in view(client?.view || world.view, src)) && get_dist(src_object, src) <= get_effective_view(client))
 		return STATUS_INTERACTIVE	// interactive (green visibility)
 	return STATUS_DISABLED			// no updates, completely disabled (red visibility)
 
@@ -42,7 +42,7 @@ var/global/datum/topic_state/default/default_topic_state = new
 		return STATUS_CLOSE
 
 	// If an object is in view then we can interact with it
-	if(src_object in view(get_effective_view(client), src))
+	if(src_object in view(client.view, src))
 		return STATUS_INTERACTIVE
 
 	// If we're installed in a chassi, rather than transfered to an inteliCard or other container, then check if we have camera view

--- a/code/modules/nano/interaction/view.dm
+++ b/code/modules/nano/interaction/view.dm
@@ -9,7 +9,7 @@ var/global/datum/topic_state/view/view_topic_state = new
 /mob/proc/view_can_use_topic(src_object)
 	if(!client)
 		return STATUS_CLOSE
-	if(src_object in view(get_effective_view(client), src))
+	if(src_object in view(client.view, src))
 		return shared_nano_interaction(src_object)
 	return STATUS_CLOSE
 

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -60,7 +60,11 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	if(linked)
 		user.reset_view(linked)
 	if(user.client)
-		user.client.view = world.view + extra_view
+		if(istext(user.client.view))
+			var/list/retrieved_view = splittext(user.client.view, "x")
+			user.client.view = "[text2num(retrieved_view[1]) + extra_view]x[text2num(retrieved_view[2]) + extra_view]"
+		else
+			user.client.view = user.client.view + extra_view
 	if(linked)
 		for(var/obj/machinery/computer/ship/sensors/sensor in linked.get_linked_machines_of_type(/obj/machinery/computer/ship))
 			sensor.reveal_contacts(user)
@@ -75,9 +79,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 /obj/machinery/computer/ship/proc/unlook(var/mob/user)
 	user.reset_view()
 	if(user.client)
-		user.client.view = world.view
 		user.client.OnResize()
-		user.reset_view()
 	if(linked)
 		for(var/obj/machinery/computer/ship/sensors/sensor in linked.get_linked_machines_of_type(/obj/machinery/computer/ship))
 			sensor.hide_contacts(user)


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Bug fix
## Why and what will this PR improve
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug fix is good
## Authorship
<!-- Describe original authors of changes to credit them. -->
[quardbreak](https://github.com/quardbreak)
## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: Fix bug where player's viewport offsets after exiting overmap interface
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.
- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin
-->
