### PR TITLE
Fixes of cooking machines

### DIFF
--- a/code/modules/food/machines/_cooker.dm
+++ b/code/modules/food/machines/_cooker.dm
@@ -101,6 +101,10 @@
 	var/old_power = use_power
 	if (!isliving(user))
 		return
+	if(stat & (NOPOWER|BROKEN))
+		update_use_power(POWER_USE_OFF)
+		to_chat(user, "It seems [src] to be unpowered right now.")
+		return
 	if (!user.check_dexterity(DEXTERITY_SIMPLE_MACHINES))
 		return
 	if (user.stat || user.restrained() || user.incapacitated())
@@ -144,6 +148,9 @@
 	if(use_power != POWER_USE_OFF)
 		heat_up()
 	. = ..()
+	if(stat & (NOPOWER|BROKEN))
+		update_use_power(POWER_USE_OFF)
+		return
 
 /obj/machinery/appliance/cooker/update_cooking_power()
 	var/temp_scale = 0


### PR DESCRIPTION
### Description of changes

When you trying to use all kind of new cooking machines(like stove, oven and etc.) you face the problem when the light goes out they still work. 

### Why and what will this PR improve
Fixes of power supply of all machines that was created in commit: https://github.com/HearthOfHestia/Nebula/commit/0df868f2b56035c20436856ac4606a401a1bc8f7 

Fix: #56 